### PR TITLE
feat: 移动端人员选择器改造为企业微信风格导航

### DIFF
--- a/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
@@ -456,7 +456,7 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
         const truncateName = (name: string) => name.length > 8 ? name.slice(0, 8) + '…' : name;
         return (
           <div style={{ display: 'flex', alignItems: 'center', padding: '8px 16px', fontSize: 13, color: '#999', overflow: 'hidden', whiteSpace: 'nowrap', flexShrink: 0, borderBottom: '1px solid #f0f0f0' }}>
-            <span onClick={onBackToRoot} style={{ color: '#1890ff', cursor: 'pointer', flexShrink: 0, WebkitTapHighlightColor: 'transparent' }}>全部</span>
+            <span onClick={onBackToRoot} style={{ color: '#1890ff', cursor: 'pointer', flexShrink: 0, WebkitTapHighlightColor: 'transparent' }}>联系人</span>
             {showEllipsis && (
               <>
                 <RightOutlined style={{ margin: '0 6px', color: '#ccc', fontSize: 10, flexShrink: 0 }} />

--- a/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
@@ -430,7 +430,7 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
         </div>
         <span style={{ fontWeight: 600, fontSize: 16 }}>选择人员</span>
         <div style={{ minWidth: 60, display: 'flex', justifyContent: 'flex-end' }}>
-          {multiple && users.length > 0 && !isSearchMode && (
+          {multiple && users.length > 0 && !isSearchMode && deptPath.length > 0 && (
             <span onClick={onToggleSelectAll} style={{ fontSize: 14, color: '#1890ff', cursor: 'pointer', WebkitTapHighlightColor: 'transparent' }}>{isAllSelected ? '取消全选' : '全选'}</span>
           )}
         </div>

--- a/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
@@ -444,6 +444,10 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
           size="large"
         />
       </div>
+      {/* 搜索与面包屑之间的分隔条 */}
+      {deptPath.length > 0 && !isSearchMode && (
+        <div style={{ height: 8, background: '#f5f5f5', flexShrink: 0 }} />
+      )}
       {/* 面包屑导航（搜索框下方，飞书风格） */}
       {deptPath.length > 0 && !isSearchMode && (() => {
         const showEllipsis = deptPath.length > 2;
@@ -451,11 +455,11 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
         const visibleStartIndex = deptPath.length > 2 ? deptPath.length - 2 : 0;
         const truncateName = (name: string) => name.length > 8 ? name.slice(0, 8) + '…' : name;
         return (
-          <div style={{ display: 'flex', alignItems: 'center', padding: '4px 16px 8px', fontSize: 13, color: '#999', overflow: 'hidden', whiteSpace: 'nowrap', flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', padding: '8px 16px', fontSize: 13, color: '#999', overflow: 'hidden', whiteSpace: 'nowrap', flexShrink: 0, borderBottom: '1px solid #f0f0f0' }}>
             <span onClick={onBackToRoot} style={{ color: '#1890ff', cursor: 'pointer', flexShrink: 0, WebkitTapHighlightColor: 'transparent' }}>全部</span>
             {showEllipsis && (
               <>
-                <span style={{ margin: '0 4px', color: '#ccc', flexShrink: 0 }}>/</span>
+                <RightOutlined style={{ margin: '0 6px', color: '#ccc', fontSize: 10, flexShrink: 0 }} />
                 <span style={{ color: '#999', flexShrink: 0 }}>...</span>
               </>
             )}
@@ -464,9 +468,9 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
               const isLast = realIndex === deptPath.length - 1;
               return (
                 <React.Fragment key={item.id}>
-                  <span style={{ margin: '0 4px', color: '#ccc', flexShrink: 0 }}>/</span>
+                  <RightOutlined style={{ margin: '0 6px', color: '#ccc', fontSize: 10, flexShrink: 0 }} />
                   {isLast ? (
-                    <span style={{ color: '#666', fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis' }}>{truncateName(item.name)}</span>
+                    <span style={{ color: '#999', overflow: 'hidden', textOverflow: 'ellipsis' }}>{truncateName(item.name)}</span>
                   ) : (
                     <span onClick={() => onDrillBack(realIndex)} style={{ color: '#1890ff', cursor: 'pointer', overflow: 'hidden', textOverflow: 'ellipsis', WebkitTapHighlightColor: 'transparent' }}>{truncateName(item.name)}</span>
                   )}

--- a/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
@@ -433,15 +433,25 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
           )}
         </div>
       </div>
-      {/* 面包屑导航 */}
+      {/* 搜索框 */}
+      <div style={{ padding: '4px 16px 8px', flexShrink: 0 }}>
+        <Input
+          placeholder="搜索姓名、邮箱或用户名"
+          prefix={<SearchOutlined />}
+          value={searchInputValue}
+          onChange={(e) => onUserSearch(e.target.value)}
+          allowClear
+          size="large"
+        />
+      </div>
+      {/* 面包屑导航（搜索框下方，飞书风格） */}
       {deptPath.length > 0 && !isSearchMode && (() => {
-        // 只显示最后2级，超过时前面用 ... 省略
         const showEllipsis = deptPath.length > 2;
         const visiblePath = deptPath.length > 2 ? deptPath.slice(-2) : deptPath;
         const visibleStartIndex = deptPath.length > 2 ? deptPath.length - 2 : 0;
         const truncateName = (name: string) => name.length > 8 ? name.slice(0, 8) + '…' : name;
         return (
-          <div style={{ display: 'flex', alignItems: 'center', padding: '0 16px 4px', fontSize: 13, color: '#999', overflow: 'hidden', whiteSpace: 'nowrap', flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', padding: '4px 16px 8px', fontSize: 13, color: '#999', overflow: 'hidden', whiteSpace: 'nowrap', flexShrink: 0 }}>
             <span onClick={onBackToRoot} style={{ color: '#1890ff', cursor: 'pointer', flexShrink: 0, WebkitTapHighlightColor: 'transparent' }}>全部</span>
             {showEllipsis && (
               <>
@@ -466,17 +476,6 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
           </div>
         );
       })()}
-      {/* 搜索框 */}
-      <div style={{ padding: '4px 16px 8px', flexShrink: 0 }}>
-        <Input
-          placeholder="搜索姓名、邮箱或用户名"
-          prefix={<SearchOutlined />}
-          value={searchInputValue}
-          onChange={(e) => onUserSearch(e.target.value)}
-          allowClear
-          size="large"
-        />
-      </div>
       {/* 主内容区：通讯录入口(初始页) / 部门卡片(钻入) + 人员列表 */}
       <div ref={scrollContainerRef} style={{ flex: 1, overflowY: 'auto', WebkitOverflowScrolling: 'touch' as any }}>
         <Spin spinning={loading}>

--- a/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
@@ -1,7 +1,6 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
-import { Tree, Input, Spin, Empty, Button, Avatar, Drawer, Badge } from 'antd';
-import { SearchOutlined, CloseOutlined, CheckOutlined, ApartmentOutlined, HolderOutlined } from '@ant-design/icons';
-import type { TreeProps } from 'antd';
+import { Input, Spin, Empty, Button, Avatar, Drawer } from 'antd';
+import { SearchOutlined, CloseOutlined, CheckOutlined, ApartmentOutlined, HolderOutlined, RightOutlined, LeftOutlined } from '@ant-design/icons';
 
 // 移动端分批渲染 Hook（callback ref 模式，兼容 Drawer 动画延迟挂载场景）
 function useMobileInfiniteScroll(totalCount: number, batchSize: number = 50, deps: any[] = []) {
@@ -65,54 +64,18 @@ const mobileStyles = `
   flex-direction: column;
   overflow: hidden;
 }
-.steedos-mobile-drawer .ant-tree .ant-tree-treenode {
-  min-height: 44px;
-  padding: 4px 0;
-  align-items: center;
-}
-.steedos-mobile-drawer .ant-tree .ant-tree-node-content-wrapper {
-  min-height: 36px;
-  line-height: 36px;
-  font-size: 15px;
-}
-.steedos-mobile-drawer .ant-tree .ant-tree-switcher {
-  width: 32px;
-  height: 36px;
-  line-height: 36px;
-}
-.steedos-mobile-tab-bar {
+.steedos-mobile-dept-card {
   display: flex;
-  border-bottom: 1px solid #f0f0f0;
-  background: #fff;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-.steedos-mobile-tab-item {
-  flex: 1;
-  text-align: center;
-  padding: 12px 0 10px;
-  font-size: 15px;
-  color: #666;
-  position: relative;
+  align-items: center;
+  padding: 14px 16px;
+  border-bottom: 1px solid #f5f5f5;
+  gap: 12px;
   cursor: pointer;
-  transition: color 0.2s;
   -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s;
 }
-.steedos-mobile-tab-item.active {
-  color: #1890ff;
-  font-weight: 500;
-}
-.steedos-mobile-tab-item.active::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 32px;
-  height: 2px;
-  background: #1890ff;
-  border-radius: 1px;
+.steedos-mobile-dept-card:active {
+  background: #f5f5f5;
 }
 .steedos-mobile-user-card {
   display: flex;
@@ -135,35 +98,42 @@ const mobileStyles = `
   border-top: 1px solid #f0f0f0;
   background: #fff;
 }
+.steedos-mobile-selected-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #fff;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
 `;
 
 interface MobileDrawerProps {
   visible: boolean;
   multiple: boolean;
   loading: boolean;
-  deptTree: any[];
-  treeKey: number;
-  deptSearchKeyword: string;
-  selectedDept: string | null;
-  selectedDeptName: string;
-  expandedKeys: React.Key[];
   users: any[];
   searchKeyword: string;
   searchInputValue: string;
   tempSelectedUsers: any[];
-  mobileActiveTab: 'dept' | 'users' | 'selected';
   clearable: boolean;
-  onSelectDept: TreeProps['onSelect'];
-  onLoadData: TreeProps['loadData'];
-  onExpandKeys: (keys: React.Key[]) => void;
-  onDeptSearch: (value: string) => void;
+  rootDeptInfo: { id: string; name: string } | null;
+  deptPath: Array<{ id: string; name: string }>;
+  currentLevelDepts: any[];
+  showSelectedPanel: boolean;
+  onDrillDown: (deptId: string, deptName: string) => void;
+  onMobileBack: () => void;
+  onToggleSelectedPanel: () => void;
   onUserSearch: (value: string) => void;
   onAddUser: (user: any) => void;
   onRemoveUser: (userId: string) => void;
   onToggleUser: (user: any) => void;
   onToggleSelectAll: () => void;
   onReorderUsers: (fromIndex: number, toIndex: number) => void;
-  onTabChange: (tab: 'dept' | 'users' | 'selected') => void;
   onOk: () => void;
   onCancel: () => void;
   onClearAll: () => void;
@@ -171,92 +141,113 @@ interface MobileDrawerProps {
 
 export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
   const {
-    visible, multiple, loading, deptTree, treeKey, deptSearchKeyword,
-    selectedDept, selectedDeptName, expandedKeys, users, searchKeyword, searchInputValue,
-    tempSelectedUsers, mobileActiveTab, clearable,
-    onSelectDept, onLoadData, onExpandKeys, onDeptSearch, onUserSearch,
-    onAddUser, onRemoveUser, onToggleUser, onToggleSelectAll,
-    onReorderUsers, onTabChange, onOk, onCancel, onClearAll
+    visible, multiple, loading, users, searchKeyword, searchInputValue,
+    tempSelectedUsers, clearable,
+    rootDeptInfo, deptPath, currentLevelDepts, showSelectedPanel,
+    onDrillDown, onMobileBack, onToggleSelectedPanel,
+    onUserSearch, onAddUser, onRemoveUser, onToggleUser, onToggleSelectAll,
+    onReorderUsers, onOk, onCancel, onClearAll
   } = props;
 
   const isAllSelected = users.length > 0 && users.every(u => tempSelectedUsers.find(s => s._id === u._id));
+  const isSearchMode = !!searchKeyword;
 
   // 移动端分批渲染（scroll 事件驱动，兼容 Drawer CSS transform）
-  const { visibleCount, scrollContainerRef } = useMobileInfiniteScroll(users.length, 50, [selectedDept, searchKeyword, mobileActiveTab]);
+  const { visibleCount, scrollContainerRef } = useMobileInfiniteScroll(users.length, 50, [deptPath.length, searchKeyword]);
 
-  // 部门面板
-  const renderDeptPanel = () => (
-    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-      <div style={{ padding: '12px 16px 8px' }}>
-        <Input placeholder="搜索部门" prefix={<SearchOutlined />} value={deptSearchKeyword} onChange={(e) => onDeptSearch(e.target.value)} allowClear size="large" />
-      </div>
-      <div style={{ flex: 1, overflowY: 'auto', padding: '0 8px', WebkitOverflowScrolling: 'touch' as any }}>
-        <Spin spinning={loading && !selectedDept && !searchKeyword}>
-          <Tree key={treeKey} treeData={deptTree} onSelect={onSelectDept} loadData={deptSearchKeyword ? undefined : onLoadData} showLine selectedKeys={selectedDept ? [selectedDept] : []} expandedKeys={expandedKeys} onExpand={onExpandKeys} />
-        </Spin>
-      </div>
-    </div>
-  );
-
-  // 人员列表面板
-  const renderUsersPanel = () => (
-    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-      {selectedDeptName && (
-        <div style={{ padding: '8px 16px', display: 'flex', alignItems: 'center', gap: 8, background: '#fafafa', borderBottom: '1px solid #f0f0f0' }}>
-          <ApartmentOutlined style={{ color: '#1890ff' }} />
-          <span style={{ flex: 1, fontSize: 14, color: '#333' }}>{selectedDeptName}</span>
-          <Button type="link" size="small" onClick={() => onTabChange('dept')} style={{ padding: 0, fontSize: 13 }}>切换部门</Button>
+  // 渲染通讯录入口栏（初始页面，点击进入部门钻入模式）
+  const renderRootBar = () => {
+    if (isSearchMode || deptPath.length > 0 || !rootDeptInfo) return null;
+    return (
+      <>
+        <div
+          className="steedos-mobile-dept-card"
+          onClick={() => onDrillDown(rootDeptInfo.id, rootDeptInfo.name)}
+        >
+          <div style={{ width: 40, height: 40, borderRadius: '50%', background: '#f0f5ff', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+            <ApartmentOutlined style={{ fontSize: 18, color: '#1890ff' }} />
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontWeight: 500, fontSize: 15 }}>通讯录</div>
+          </div>
+          <RightOutlined style={{ color: '#ccc', fontSize: 14, flexShrink: 0 }} />
         </div>
-      )}
-      {/* 搜索框 + 全选同行（参考钉钉/飞书规范） */}
-      <div style={{ padding: '8px 16px', display: 'flex', alignItems: 'center', gap: 8 }}>
-        <Input placeholder="搜索姓名、邮箱或用户名" prefix={<SearchOutlined />} value={searchInputValue} onChange={(e) => onUserSearch(e.target.value)} allowClear size="large" style={{ flex: 1 }} />
-        {multiple && users.length > 0 && (
-          <Button size="small" onClick={onToggleSelectAll} style={{ flexShrink: 0 }}>{isAllSelected ? '取消全选' : '全选'}</Button>
+        {users.length > 0 && (
+          <div style={{ height: 8, background: '#f5f5f5' }} />
         )}
-      </div>
-      <div ref={scrollContainerRef} style={{ flex: 1, overflowY: 'auto', WebkitOverflowScrolling: 'touch' as any }}>
-        <Spin spinning={loading}>
-          {users.length > 0 ? (
-            <>
-              {users.slice(0, visibleCount).map((user: any) => {
-                const isSelected = !!tempSelectedUsers.find(u => u._id === user._id);
-                return (
-                  <div key={user._id} className="steedos-mobile-user-card" onClick={() => onToggleUser(user)} style={{ opacity: isSelected ? 0.7 : 1 }}>
-                    <Avatar src={user.avatar ? `/api/v6/users/${user.user}/avatar` : undefined} size={40} style={{ backgroundColor: user.avatar ? undefined : '#1890ff', flexShrink: 0 }}>
-                      {!user.avatar && user.name?.charAt(0)}
-                    </Avatar>
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ fontWeight: 500, fontSize: 15, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{user.name}</div>
-                      <div style={{ fontSize: 12, color: '#999', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginTop: 2 }}>
-                        {user.organization?.name}{user.position ? ` · ${user.position}` : ''}
-                      </div>
-                      {(user.email || user.mobile || user.username) && (
-                        <div style={{ fontSize: 12, color: '#999', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginTop: 1 }}>
-                          {user.email || user.mobile || user.username}
-                        </div>
-                      )}
-                    </div>
-                    <div style={{ width: 32, height: 32, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, background: isSelected ? '#1890ff' : '#f0f0f0' }}>
-                      {isSelected ? <CheckOutlined style={{ color: '#fff', fontSize: 14 }} /> : <span style={{ color: '#bbb', fontSize: 18, lineHeight: 1 }}>+</span>}
-                    </div>
+      </>
+    );
+  };
+
+  // 渲染部门卡片（钻入式）
+  const renderDeptCards = () => {
+    if (isSearchMode || deptPath.length === 0 || currentLevelDepts.length === 0) return null;
+    return (
+      <>
+        {currentLevelDepts.map((dept: any) => (
+          <div
+            key={dept._id || dept.id || dept.key || dept.value}
+            className="steedos-mobile-dept-card"
+            onClick={() => onDrillDown(dept._id || dept.id || dept.key || dept.value, dept.title || dept.name || dept.label)}
+          >
+            <div style={{ width: 40, height: 40, borderRadius: '50%', background: '#f0f5ff', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+              <ApartmentOutlined style={{ fontSize: 18, color: '#1890ff' }} />
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontWeight: 500, fontSize: 15, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {dept.title || dept.name || dept.label}
+              </div>
+            </div>
+            <RightOutlined style={{ color: '#ccc', fontSize: 14, flexShrink: 0 }} />
+          </div>
+        ))}
+        {/* 部门与人员之间的分隔线 */}
+        {users.length > 0 && (
+          <div style={{ height: 8, background: '#f5f5f5' }} />
+        )}
+      </>
+    );
+  };
+
+  // 渲染人员列表（当前部门下的人员 或 搜索结果）
+  const renderUserList = () => (
+    <>
+      {users.length > 0 ? (
+        <>
+          {users.slice(0, visibleCount).map((user: any) => {
+            const isSelected = !!tempSelectedUsers.find(u => u._id === user._id);
+            return (
+              <div key={user._id} className="steedos-mobile-user-card" onClick={() => onToggleUser(user)} style={{ opacity: isSelected ? 0.7 : 1 }}>
+                <Avatar src={user.avatar ? `/api/v6/users/${user.user}/avatar` : undefined} size={40} style={{ backgroundColor: user.avatar ? undefined : '#1890ff', flexShrink: 0 }}>
+                  {!user.avatar && user.name?.charAt(0)}
+                </Avatar>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontWeight: 500, fontSize: 15, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{user.name}</div>
+                  <div style={{ fontSize: 12, color: '#999', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginTop: 2 }}>
+                    {user.organization?.name}{user.position ? ` · ${user.position}` : ''}
                   </div>
-                );
-              })}
-              {visibleCount < users.length && (
-                <div style={{ height: 48, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', fontSize: 13 }}>
-                  加载更多...
+                  {(user.email || user.mobile || user.username) && (
+                    <div style={{ fontSize: 12, color: '#999', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginTop: 1 }}>
+                      {user.email || user.mobile || user.username}
+                    </div>
+                  )}
                 </div>
-              )}
-            </>
-          ) : (selectedDept || searchKeyword) && !loading ? (
-            <Empty description="暂无人员" style={{ marginTop: 60 }} />
-          ) : !loading ? (
-            <Empty description="请选择部门" style={{ marginTop: 60 }} />
-          ) : null}
-        </Spin>
-      </div>
-    </div>
+                <div style={{ width: 32, height: 32, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, background: isSelected ? '#1890ff' : '#f0f0f0' }}>
+                  {isSelected ? <CheckOutlined style={{ color: '#fff', fontSize: 14 }} /> : <span style={{ color: '#bbb', fontSize: 18, lineHeight: 1 }}>+</span>}
+                </div>
+              </div>
+            );
+          })}
+          {visibleCount < users.length && (
+            <div style={{ height: 48, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', fontSize: 13 }}>
+              加载更多...
+            </div>
+          )}
+        </>
+      ) : !loading ? (
+        <Empty description={searchKeyword ? "未找到匹配的人员" : "暂无人员"} style={{ marginTop: 60 }} />
+      ) : null}
+    </>
   );
 
   // 触摸拖拽排序状态
@@ -355,20 +346,10 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
     }
   }, [onReorderUsers]);
 
-  // 已选面板
-  const renderSelectedPanel = () => (
-    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-      <div style={{ padding: '8px 16px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <span style={{ fontWeight: 500, fontSize: 15 }}>已选中 ({tempSelectedUsers.length})</span>
-        {clearable && tempSelectedUsers.length > 0 && (
-          <Button type="link" danger size="small" onClick={onClearAll} style={{ padding: 0 }}>清空全部</Button>
-        )}
-      </div>
-      {multiple && tempSelectedUsers.length > 1 && (
-        <div style={{ padding: '0 16px 6px', fontSize: 12, color: '#999' }}>长按拖拽可调整顺序</div>
-      )}
-      <div ref={selectedListRef} style={{ flex: 1, overflowY: 'auto', WebkitOverflowScrolling: 'touch' as any }}>
-        {tempSelectedUsers.length > 0 ? tempSelectedUsers.map((user, index) => {
+  // 已选列表（供已选面板使用）
+  const renderSelectedList = () => (
+    <div ref={selectedListRef} style={{ flex: 1, overflowY: 'auto', WebkitOverflowScrolling: 'touch' as any }}>
+      {tempSelectedUsers.length > 0 ? tempSelectedUsers.map((user, index) => {
           const isDragging = dragActiveIndex === index;
           const isDropTarget = dropTargetIndex === index && dragActiveIndex !== null && dragActiveIndex !== index;
           return (
@@ -414,7 +395,7 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
           <Empty description="未选择" style={{ marginTop: 60 }} image={Empty.PRESENTED_IMAGE_SIMPLE} />
         )}
       </div>
-    </div>
+
   );
 
   return (
@@ -426,38 +407,85 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
       destroyOnClose
       rootClassName="steedos-mobile-drawer"
       onClose={onCancel}
-      styles={{ body: { padding: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' } }}
+      styles={{ body: { padding: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden', position: 'relative' } }}
     >
       <style>{mobileStyles}</style>
       {/* 顶部拖拽条 */}
       <div style={{ display: 'flex', justifyContent: 'center', padding: '8px 0 4px' }}>
         <div style={{ width: 36, height: 4, borderRadius: 2, background: '#ddd' }} />
       </div>
-      {/* 标题栏：确认入口统一在底部，顶部只保留取消 */}
+      {/* 标题栏 */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '4px 16px 8px' }}>
-        <Button type="text" onClick={onCancel} style={{ padding: 0, color: '#666' }}>取消</Button>
-        <span style={{ fontWeight: 600, fontSize: 16 }}>选择人员</span>
+        {deptPath.length > 0 ? (
+          <Button type="text" onClick={onMobileBack} style={{ padding: 0, color: '#1890ff' }}>
+            <LeftOutlined style={{ marginRight: 4 }} />返回
+          </Button>
+        ) : (
+          <Button type="text" onClick={onCancel} style={{ padding: 0, color: '#666' }}>取消</Button>
+        )}
+        <span style={{ fontWeight: 600, fontSize: 16 }}>
+          {deptPath.length > 0 ? deptPath[deptPath.length - 1].name : '选择人员'}
+        </span>
         <span style={{ width: 40 }} />
       </div>
-      {/* Tab栏 */}
-      <div className="steedos-mobile-tab-bar">
-        <div className={`steedos-mobile-tab-item ${mobileActiveTab === 'dept' ? 'active' : ''}`} onClick={() => onTabChange('dept')}>部门</div>
-        <div className={`steedos-mobile-tab-item ${mobileActiveTab === 'users' ? 'active' : ''}`} onClick={() => onTabChange('users')}>人员</div>
-        <div className={`steedos-mobile-tab-item ${mobileActiveTab === 'selected' ? 'active' : ''}`} onClick={() => onTabChange('selected')}>
-          已选{tempSelectedUsers.length > 0 ? <Badge count={tempSelectedUsers.length} size="small" offset={[4, -2]} style={{ fontSize: 10 }} /> : null}
+      {/* 搜索框 + 全选 */}
+      <div style={{ padding: '4px 16px 8px', display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+        <Input
+          placeholder="搜索姓名、邮箱或用户名"
+          prefix={<SearchOutlined />}
+          value={searchInputValue}
+          onChange={(e) => onUserSearch(e.target.value)}
+          allowClear
+          size="large"
+          style={{ flex: 1 }}
+        />
+        {multiple && users.length > 0 && !isSearchMode && (
+          <Button size="small" onClick={onToggleSelectAll} style={{ flexShrink: 0 }}>{isAllSelected ? '取消全选' : '全选'}</Button>
+        )}
+      </div>
+      {/* 主内容区：通讯录入口(初始页) / 部门卡片(钻入) + 人员列表 */}
+      <div ref={scrollContainerRef} style={{ flex: 1, overflowY: 'auto', WebkitOverflowScrolling: 'touch' as any }}>
+        <Spin spinning={loading}>
+          {renderRootBar()}
+          {renderDeptCards()}
+          {renderUserList()}
+        </Spin>
+      </div>
+      {/* 已选面板（覆盖层，点击底部栏"已选N人"切换） */}
+      {showSelectedPanel && (
+        <div className="steedos-mobile-selected-overlay">
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 16px', borderBottom: '1px solid #f0f0f0' }}>
+            <span style={{ fontWeight: 600, fontSize: 16 }}>已选中 ({tempSelectedUsers.length})</span>
+            <Button type="text" onClick={onToggleSelectedPanel} style={{ padding: 0, color: '#666' }}>返回</Button>
+          </div>
+          {clearable && tempSelectedUsers.length > 0 && (
+            <div style={{ padding: '4px 16px', display: 'flex', justifyContent: 'flex-end' }}>
+              <Button type="link" danger size="small" onClick={onClearAll} style={{ padding: 0 }}>清空全部</Button>
+            </div>
+          )}
+          {multiple && tempSelectedUsers.length > 1 && (
+            <div style={{ padding: '0 16px 6px', fontSize: 12, color: '#999' }}>长按拖拽可调整顺序</div>
+          )}
+          {renderSelectedList()}
         </div>
-      </div>
-      {/* 内容区 */}
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-        {mobileActiveTab === 'dept' && renderDeptPanel()}
-        {mobileActiveTab === 'users' && renderUsersPanel()}
-        {mobileActiveTab === 'selected' && renderSelectedPanel()}
-      </div>
-      {/* 底部操作栏（仅多选模式） */}
-      {multiple && (
+      )}
+      {/* 底部操作栏 */}
+      {multiple ? (
         <div className="steedos-mobile-bottom-bar">
-          <span style={{ fontSize: 14, color: '#666' }}>已选 {tempSelectedUsers.length} 人</span>
+          <span
+            style={{ fontSize: 14, color: tempSelectedUsers.length > 0 ? '#1890ff' : '#666', cursor: 'pointer' }}
+            onClick={tempSelectedUsers.length > 0 ? onToggleSelectedPanel : undefined}
+          >
+            已选 {tempSelectedUsers.length} 人 {tempSelectedUsers.length > 0 && !showSelectedPanel ? '▲' : tempSelectedUsers.length > 0 && showSelectedPanel ? '▼' : ''}
+          </span>
           <Button type="primary" onClick={onOk}>确定</Button>
+        </div>
+      ) : (
+        <div className="steedos-mobile-bottom-bar">
+          <span style={{ fontSize: 14, color: '#666' }}>
+            {tempSelectedUsers.length > 0 ? `已选: ${tempSelectedUsers[0]?.name}` : '请选择人员'}
+          </span>
+          <Button type="primary" onClick={onOk} disabled={tempSelectedUsers.length === 0}>确定</Button>
         </div>
       )}
     </Drawer>

--- a/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
@@ -217,7 +217,12 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
           {users.slice(0, visibleCount).map((user: any) => {
             const isSelected = !!tempSelectedUsers.find(u => u._id === user._id);
             return (
-              <div key={user._id} className="steedos-mobile-user-card" onClick={() => onToggleUser(user)} style={{ opacity: isSelected ? 0.7 : 1 }}>
+              <div key={user._id} className="steedos-mobile-user-card" onClick={() => onToggleUser(user)}>
+                {multiple && (
+                  <div style={{ width: 20, height: 20, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, background: isSelected ? '#1890ff' : 'transparent', border: isSelected ? 'none' : '1.5px solid #d9d9d9' }}>
+                    {isSelected && <CheckOutlined style={{ color: '#fff', fontSize: 11 }} />}
+                  </div>
+                )}
                 <Avatar src={user.avatar ? `/api/v6/users/${user.user}/avatar` : undefined} size={40} style={{ backgroundColor: user.avatar ? undefined : '#1890ff', flexShrink: 0 }}>
                   {!user.avatar && user.name?.charAt(0)}
                 </Avatar>
@@ -231,9 +236,6 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
                       {user.email || user.mobile || user.username}
                     </div>
                   )}
-                </div>
-                <div style={{ width: 32, height: 32, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, background: isSelected ? '#1890ff' : '#f0f0f0' }}>
-                  {isSelected ? <CheckOutlined style={{ color: '#fff', fontSize: 14 }} /> : <span style={{ color: '#bbb', fontSize: 18, lineHeight: 1 }}>+</span>}
                 </div>
               </div>
             );
@@ -416,20 +418,25 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
       </div>
       {/* 标题栏 */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '4px 16px 8px' }}>
-        {deptPath.length > 0 ? (
-          <Button type="text" onClick={onMobileBack} style={{ padding: 0, color: '#1890ff' }}>
-            <LeftOutlined style={{ marginRight: 4 }} />返回
-          </Button>
-        ) : (
-          <Button type="text" onClick={onCancel} style={{ padding: 0, color: '#666' }}>取消</Button>
-        )}
-        <span style={{ fontWeight: 600, fontSize: 16 }}>
-          {deptPath.length > 0 ? deptPath[deptPath.length - 1].name : '选择人员'}
-        </span>
-        <span style={{ width: 40 }} />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 28, minWidth: 60 }}>
+          {deptPath.length > 0 && (
+            <span onClick={onMobileBack} style={{ color: '#1890ff', fontSize: 18, lineHeight: 1, cursor: 'pointer', WebkitTapHighlightColor: 'transparent', padding: '4px 0' }}>
+              <LeftOutlined />
+            </span>
+          )}
+          <span onClick={onCancel} style={{ color: '#666', fontSize: 16, lineHeight: 1, cursor: 'pointer', WebkitTapHighlightColor: 'transparent', padding: '4px 0' }}>
+            <CloseOutlined />
+          </span>
+        </div>
+        <span style={{ fontWeight: 600, fontSize: 16 }}>选择人员</span>
+        <div style={{ minWidth: 60, display: 'flex', justifyContent: 'flex-end' }}>
+          {multiple && users.length > 0 && !isSearchMode && (
+            <span onClick={onToggleSelectAll} style={{ fontSize: 14, color: '#1890ff', cursor: 'pointer', WebkitTapHighlightColor: 'transparent' }}>{isAllSelected ? '取消全选' : '全选'}</span>
+          )}
+        </div>
       </div>
-      {/* 搜索框 + 全选 */}
-      <div style={{ padding: '4px 16px 8px', display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+      {/* 搜索框 */}
+      <div style={{ padding: '4px 16px 8px', flexShrink: 0 }}>
         <Input
           placeholder="搜索姓名、邮箱或用户名"
           prefix={<SearchOutlined />}
@@ -437,11 +444,7 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
           onChange={(e) => onUserSearch(e.target.value)}
           allowClear
           size="large"
-          style={{ flex: 1 }}
         />
-        {multiple && users.length > 0 && !isSearchMode && (
-          <Button size="small" onClick={onToggleSelectAll} style={{ flexShrink: 0 }}>{isAllSelected ? '取消全选' : '全选'}</Button>
-        )}
       </div>
       {/* 主内容区：通讯录入口(初始页) / 部门卡片(钻入) + 人员列表 */}
       <div ref={scrollContainerRef} style={{ flex: 1, overflowY: 'auto', WebkitOverflowScrolling: 'touch' as any }}>

--- a/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
@@ -127,6 +127,8 @@ interface MobileDrawerProps {
   showSelectedPanel: boolean;
   onDrillDown: (deptId: string, deptName: string) => void;
   onMobileBack: () => void;
+  onDrillBack: (targetIndex: number) => void;
+  onBackToRoot: () => void;
   onToggleSelectedPanel: () => void;
   onUserSearch: (value: string) => void;
   onAddUser: (user: any) => void;
@@ -144,7 +146,7 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
     visible, multiple, loading, users, searchKeyword, searchInputValue,
     tempSelectedUsers, clearable,
     rootDeptInfo, deptPath, currentLevelDepts, showSelectedPanel,
-    onDrillDown, onMobileBack, onToggleSelectedPanel,
+    onDrillDown, onMobileBack, onDrillBack, onBackToRoot, onToggleSelectedPanel,
     onUserSearch, onAddUser, onRemoveUser, onToggleUser, onToggleSelectAll,
     onReorderUsers, onOk, onCancel, onClearAll
   } = props;
@@ -431,6 +433,39 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
           )}
         </div>
       </div>
+      {/* 面包屑导航 */}
+      {deptPath.length > 0 && !isSearchMode && (() => {
+        // 只显示最后2级，超过时前面用 ... 省略
+        const showEllipsis = deptPath.length > 2;
+        const visiblePath = deptPath.length > 2 ? deptPath.slice(-2) : deptPath;
+        const visibleStartIndex = deptPath.length > 2 ? deptPath.length - 2 : 0;
+        const truncateName = (name: string) => name.length > 8 ? name.slice(0, 8) + '…' : name;
+        return (
+          <div style={{ display: 'flex', alignItems: 'center', padding: '0 16px 4px', fontSize: 13, color: '#999', overflow: 'hidden', whiteSpace: 'nowrap', flexShrink: 0 }}>
+            <span onClick={onBackToRoot} style={{ color: '#1890ff', cursor: 'pointer', flexShrink: 0, WebkitTapHighlightColor: 'transparent' }}>全部</span>
+            {showEllipsis && (
+              <>
+                <span style={{ margin: '0 4px', color: '#ccc', flexShrink: 0 }}>/</span>
+                <span style={{ color: '#999', flexShrink: 0 }}>...</span>
+              </>
+            )}
+            {visiblePath.map((item, i) => {
+              const realIndex = visibleStartIndex + i;
+              const isLast = realIndex === deptPath.length - 1;
+              return (
+                <React.Fragment key={item.id}>
+                  <span style={{ margin: '0 4px', color: '#ccc', flexShrink: 0 }}>/</span>
+                  {isLast ? (
+                    <span style={{ color: '#666', fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis' }}>{truncateName(item.name)}</span>
+                  ) : (
+                    <span onClick={() => onDrillBack(realIndex)} style={{ color: '#1890ff', cursor: 'pointer', overflow: 'hidden', textOverflow: 'ellipsis', WebkitTapHighlightColor: 'transparent' }}>{truncateName(item.name)}</span>
+                  )}
+                </React.Fragment>
+              );
+            })}
+          </div>
+        );
+      })()}
       {/* 搜索框 */}
       <div style={{ padding: '4px 16px 8px', flexShrink: 0 }}>
         <Input

--- a/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
@@ -460,7 +460,7 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
             {showEllipsis && (
               <>
                 <RightOutlined style={{ margin: '0 6px', color: '#ccc', fontSize: 10, flexShrink: 0 }} />
-                <span style={{ color: '#999', flexShrink: 0 }}>...</span>
+                <span style={{ color: '#999', flexShrink: 0, display: 'flex', alignItems: 'center', lineHeight: 1 }}>···</span>
               </>
             )}
             {visiblePath.map((item, i) => {

--- a/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/MobileDrawerContent.tsx
@@ -51,7 +51,7 @@ function useMobileInfiniteScroll(totalCount: number, batchSize: number = 50, dep
 
 const mobileStyles = `
 .steedos-mobile-drawer .ant-drawer-content-wrapper {
-  border-radius: 16px 16px 0 0 !important;
+  border-radius: 0 !important;
   overflow: hidden;
 }
 .steedos-mobile-drawer .ant-drawer-header {
@@ -404,7 +404,7 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
     <Drawer
       open={visible}
       placement="bottom"
-      height="92vh"
+      height="100vh"
       closable={false}
       destroyOnClose
       rootClassName="steedos-mobile-drawer"
@@ -412,12 +412,8 @@ export const MobileDrawerContent: React.FC<MobileDrawerProps> = (props) => {
       styles={{ body: { padding: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden', position: 'relative' } }}
     >
       <style>{mobileStyles}</style>
-      {/* 顶部拖拽条 */}
-      <div style={{ display: 'flex', justifyContent: 'center', padding: '8px 0 4px' }}>
-        <div style={{ width: 36, height: 4, borderRadius: 2, background: '#ddd' }} />
-      </div>
       {/* 标题栏 */}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '4px 16px 8px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 16px 8px' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 28, minWidth: 60 }}>
           {deptPath.length > 0 && (
             <span onClick={onMobileBack} style={{ color: '#1890ff', fontSize: 18, lineHeight: 1, cursor: 'pointer', WebkitTapHighlightColor: 'transparent', padding: '4px 0' }}>

--- a/packages/@steedos-widgets/amis-object/src/components/SteedosUserSelector.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/SteedosUserSelector.tsx
@@ -290,6 +290,7 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
       setSearchKeyword('');
       setSearchInputValue(''); // 同步清空搜索输入框
       
+      let mobileUserLoading = false;
       fetchDeptTree()
         .then(data => {
           const rootNodes = data as DataNode[];
@@ -309,7 +310,8 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
               setDeptPath([]); // 初始页面，不自动钻入
               setSelectedDept(rootId);
               // 加载全部人员（递归，与PC端一致）
-              setLoading(true);
+              // 标记移动端用户加载中，外层 finally 不关闭 loading
+              mobileUserLoading = true;
               fetchUsers(rootId).then(allUsers => {
                 setUsers(allUsers);
               }).catch(() => {
@@ -341,7 +343,10 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
             }
           });
         })
-        .finally(() => setLoading(false));
+        .finally(() => {
+          // 移动端用户列表正在单独加载时，不在这里关闭 loading
+          if (!mobileUserLoading) setLoading(false);
+        });
     }
   }, [visible, fetchDeptTree]);
 

--- a/packages/@steedos-widgets/amis-object/src/components/SteedosUserSelector.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/SteedosUserSelector.tsx
@@ -48,6 +48,27 @@ interface DataNode {
   children?: DataNode[];
 }
 
+// 移动端获取直属成员（不递归子部门）
+async function defaultFetchDirectUsers(organizationId: string): Promise<any[]> {
+  const filters = [
+    [["user_accepted", "=", true]],
+    "and",
+    [["organization", "=", organizationId]]
+  ];
+  const query = `{rows:space_users(filters: [${filters.map(f => typeof f === 'string' ? `"${f}"` : JSON.stringify(f)).join(',')}], top: 1000, skip: 0, sort: "sort_no desc,name asc"){_id,user,space,name,mobile,email,position,sort_no,username,avatar,organization,_display:_ui{sort_no,organization}}}`;
+  const res = await fetch('/graphql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query })
+  });
+  const data = await res.json();
+  return (data.data?.rows || []).map((user: any) => ({
+    _id: user._id, user: user.user, name: user.name, email: user.email,
+    mobile: user.mobile, position: user.position, username: user.username,
+    avatar: user.avatar, organization: user.organization
+  }));
+}
+
 // 默认用户数据获取方法
 async function defaultFetchUsers(organizationId?: string, keyword?: string): Promise<any[]> {
   if (!organizationId && !keyword) {
@@ -198,6 +219,11 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
   const isMobile = useIsMobile();
   const [mobileActiveTab, setMobileActiveTab] = useState<'dept' | 'users' | 'selected'>('dept');
   const [selectedDeptName, setSelectedDeptName] = useState<string>('');
+  // 移动端钻入式导航状态
+  const [deptPath, setDeptPath] = useState<Array<{id: string, name: string}>>([]);
+  const [currentLevelDepts, setCurrentLevelDepts] = useState<any[]>([]);
+  const [showSelectedPanel, setShowSelectedPanel] = useState(false);
+  const [rootDeptInfo, setRootDeptInfo] = useState<{ id: string; name: string } | null>(null);
 
   // PC端分批渲染
   const { visibleCount: pcVisibleCount, sentinelRef: pcSentinelRef } = useInfiniteScroll(users.length, 50, [selectedDept, searchKeyword]);
@@ -273,10 +299,23 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
           setExpandedKeys(firstLevelKeys);
           // 默认选中第一个根节点
           if (firstLevelKeys.length > 0) {
-            setSelectedDept(String(firstLevelKeys[0]));
             // 移动端默认进入人员Tab，需要同步显示部门名称
             if (isMobile && rootNodes[0]) {
               setSelectedDeptName(String(rootNodes[0].title || ''));
+              // 移动端：记录根部门信息，初始页面显示全部人员（递归）+ 通讯录入口
+              const rootId = String(rootNodes[0].key);
+              const rootName = String(rootNodes[0].title || '');
+              setRootDeptInfo({ id: rootId, name: rootName });
+              setDeptPath([]); // 初始页面，不自动钻入
+              setSelectedDept(rootId);
+              // 加载全部人员（递归，与PC端一致）
+              fetchUsers(rootId).then(allUsers => {
+                setUsers(allUsers);
+              }).catch(() => {
+                setUsers([]);
+              });
+            } else {
+              setSelectedDept(String(firstLevelKeys[0]));
             }
           }
           // 关键修复：手动加载已展开根节点的子节点数据
@@ -303,8 +342,9 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
     }
   }, [visible, fetchDeptTree]);
 
-  // 加载选中部门的用户
+  // 加载选中部门的用户（移动端钻入式导航由 handleDrillDown/handleDrillBack 单独处理直属成员）
   useEffect(() => {
+    if (isMobile) return; // 移动端跳过，由钻入逻辑直接管理用户加载
     if (selectedDept || searchKeyword) {
       setLoading(true);
       fetchUsers(selectedDept || undefined, searchKeyword || undefined)
@@ -313,7 +353,7 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
     } else {
       setUsers([]);
     }
-  }, [selectedDept, searchKeyword, fetchUsers]);
+  }, [selectedDept, searchKeyword, fetchUsers, isMobile]);
 
   // 递归更新树节点
   const updateTreeData = (list: DataNode[], key: React.Key, children: DataNode[]): DataNode[] =>
@@ -406,8 +446,26 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
       if (searchValue) {
         setSelectedDept(null);      // 互斥规则：输入关键字时清空部门选中
         setSelectedDeptName('');    // 同步清空移动端顶部部门状态栏
+        if (isMobile) {
+          // 移动端手动触发搜索（useEffect 已跳过移动端）
+          setLoading(true);
+          fetchUsers(undefined, searchValue)
+            .then(data => setUsers(data))
+            .finally(() => setLoading(false));
+        }
+      } else if (isMobile && deptPath.length > 0) {
+        // 移动端：清空搜索后恢复到当前钻入位置，加载直属成员
+        const currentDept = deptPath[deptPath.length - 1];
+        setSelectedDept(currentDept.id);
+        defaultFetchDirectUsers(currentDept.id).then(users => setUsers(users)).catch(() => {});
+      } else if (isMobile && deptPath.length === 0) {
+        // 移动端：清空搜索后回到初始页面，加载全部人员（递归）
+        if (rootDeptInfo) {
+          setSelectedDept(rootDeptInfo.id);
+          fetchUsers(rootDeptInfo.id).then(allUsers => setUsers(allUsers)).catch(() => {});
+        }
       } else if (deptTree.length > 0) {
-        // 清空关键字时恢复默认选中第一个根节点
+        // PC端：清空关键字时恢复默认选中第一个根节点
         setSelectedDept(String(deptTree[0].key));
       }
     }, 300);
@@ -494,10 +552,14 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
   const handleOpen = () => {
     setVisible(true);
     setTempSelectedUsers([...selectedUsers]);
-    // 移动端：重置Tab状态，默认进入"人员"Tab（已自动选中第一个根部门）
+    // 移动端：重置状态
     if (isMobile) {
       setMobileActiveTab('users');
       setSelectedDeptName('');
+      setShowSelectedPanel(false);
+      setDeptPath([]);
+      setCurrentLevelDepts([]);
+      setRootDeptInfo(null);
     }
   };
 
@@ -529,6 +591,104 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
     setTempSelectedUsers([...selectedUsers]);
     setVisible(false);
   };
+
+  // 移动端：钻入子部门
+  const handleDrillDown = useCallback(async (deptId: string, deptName: string) => {
+    setDeptPath(prev => [...prev, { id: deptId, name: deptName }]);
+    setSelectedDept(deptId);
+    setSearchKeyword('');
+    setSearchInputValue('');
+    setLoading(true);
+    try {
+      // 并行加载：子部门 + 直属成员（不递归）
+      const [children, directUsers] = await Promise.all([
+        fetchDeptTree(deptId),
+        defaultFetchDirectUsers(deptId)
+      ]);
+      setCurrentLevelDepts(children);
+      setUsers(directUsers);
+    } catch {
+      setCurrentLevelDepts([]);
+      setUsers([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchDeptTree]);
+
+  // 移动端：面包屑返回
+  const handleDrillBack = useCallback(async (targetIndex: number) => {
+    if (targetIndex < 0) return;
+    const newPath = deptPath.slice(0, targetIndex + 1);
+    setDeptPath(newPath);
+    const targetDept = newPath[newPath.length - 1];
+    setSelectedDept(targetDept.id);
+    setSearchKeyword('');
+    setSearchInputValue('');
+    setLoading(true);
+    try {
+      const [children, directUsers] = await Promise.all([
+        fetchDeptTree(targetDept.id),
+        defaultFetchDirectUsers(targetDept.id)
+      ]);
+      setCurrentLevelDepts(children);
+      setUsers(directUsers);
+    } catch {
+      setCurrentLevelDepts([]);
+      setUsers([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [deptPath, fetchDeptTree]);
+
+  // 移动端：返回到初始页面（通讯录入口 + 全部人员递归列表）
+  const handleBackToRoot = useCallback(async () => {
+    if (!rootDeptInfo) return;
+    setDeptPath([]);
+    setSelectedDept(rootDeptInfo.id);
+    setSearchKeyword('');
+    setSearchInputValue('');
+    setCurrentLevelDepts([]);
+    setLoading(true);
+    try {
+      const allUsers = await fetchUsers(rootDeptInfo.id);
+      setUsers(allUsers);
+    } catch {
+      setUsers([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [rootDeptInfo, fetchUsers]);
+
+  // 移动端：返回上一级（企业微信风格，左上角返回按钮）
+  const handleMobileBack = useCallback(async () => {
+    if (deptPath.length <= 0) return;
+    if (deptPath.length === 1) {
+      // 在根部门级别，返回初始页面
+      await handleBackToRoot();
+    } else {
+      // 返回上一级部门
+      const newPath = deptPath.slice(0, -1);
+      setDeptPath(newPath);
+      const targetDept = newPath[newPath.length - 1];
+      setSelectedDept(targetDept.id);
+      setSearchKeyword('');
+      setSearchInputValue('');
+      setLoading(true);
+      try {
+        const [children, directUsers] = await Promise.all([
+          fetchDeptTree(targetDept.id),
+          defaultFetchDirectUsers(targetDept.id)
+        ]);
+        setCurrentLevelDepts(children);
+        setUsers(directUsers);
+      } catch {
+        setCurrentLevelDepts([]);
+        setUsers([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+  }, [deptPath, handleBackToRoot, fetchDeptTree]);
 
   // 移动端：拖拽排序已选用户
   const handleReorderUsers = useCallback((fromIndex: number, toIndex: number) => {
@@ -802,35 +962,30 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
         </div>
       </Modal>}
 
-      {/* ====== 移动端：Drawer底部抽屉 + Tab切换布局 ====== */}
+      {/* ====== 移动端：Drawer底部抽屉 + 钻入式导航 ====== */}
       {isMobile && visible && (
         <MobileDrawerContent
           visible={visible}
           multiple={multiple}
           loading={loading}
-          deptTree={deptTree}
-          treeKey={treeKey}
-          deptSearchKeyword={deptSearchKeyword}
-          selectedDept={selectedDept}
-          selectedDeptName={selectedDeptName}
-          expandedKeys={expandedKeys}
           users={users}
           searchKeyword={searchKeyword}
           searchInputValue={searchInputValue}
           tempSelectedUsers={tempSelectedUsers}
-          mobileActiveTab={mobileActiveTab}
           clearable={clearable}
-          onSelectDept={onSelectDept}
-          onLoadData={onLoadData}
-          onExpandKeys={setExpandedKeys}
-          onDeptSearch={handleDeptSearch}
+          rootDeptInfo={rootDeptInfo}
+          deptPath={deptPath}
+          currentLevelDepts={currentLevelDepts}
+          showSelectedPanel={showSelectedPanel}
+          onDrillDown={handleDrillDown}
+          onMobileBack={handleMobileBack}
+          onToggleSelectedPanel={() => setShowSelectedPanel(v => !v)}
           onUserSearch={handleSearch}
           onAddUser={handleAddUser}
           onRemoveUser={handleRemoveUser}
           onToggleUser={handleToggleUser}
           onToggleSelectAll={handleToggleSelectAll}
           onReorderUsers={handleReorderUsers}
-          onTabChange={setMobileActiveTab}
           onOk={handleOk}
           onCancel={handleCancel}
           onClearAll={() => setTempSelectedUsers([])}

--- a/packages/@steedos-widgets/amis-object/src/components/SteedosUserSelector.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/SteedosUserSelector.tsx
@@ -309,10 +309,13 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
               setDeptPath([]); // 初始页面，不自动钻入
               setSelectedDept(rootId);
               // 加载全部人员（递归，与PC端一致）
+              setLoading(true);
               fetchUsers(rootId).then(allUsers => {
                 setUsers(allUsers);
               }).catch(() => {
                 setUsers([]);
+              }).finally(() => {
+                setLoading(false);
               });
             } else {
               setSelectedDept(String(firstLevelKeys[0]));

--- a/packages/@steedos-widgets/amis-object/src/components/SteedosUserSelector.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/SteedosUserSelector.tsx
@@ -461,16 +461,18 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
             .then(data => setUsers(data))
             .finally(() => setLoading(false));
         }
-      } else if (isMobile && deptPath.length > 0) {
-        // 移动端：清空搜索后恢复到当前钻入位置，加载直属成员
-        const currentDept = deptPath[deptPath.length - 1];
-        setSelectedDept(currentDept.id);
-        defaultFetchDirectUsers(currentDept.id).then(users => setUsers(users)).catch(() => {});
-      } else if (isMobile && deptPath.length === 0) {
-        // 移动端：清空搜索后回到初始页面，加载全部人员（递归）
+      } else if (isMobile) {
+        // 移动端：清空搜索后完全回到初始页面（与首次打开一致）
         if (rootDeptInfo) {
+          setDeptPath([]);
+          setCurrentLevelDepts([]);
           setSelectedDept(rootDeptInfo.id);
-          fetchUsers(rootDeptInfo.id).then(allUsers => setUsers(allUsers)).catch(() => {});
+          setLoading(true);
+          fetchUsers(rootDeptInfo.id).then(allUsers => {
+            setUsers(allUsers);
+          }).catch(() => {
+            setUsers([]);
+          }).finally(() => setLoading(false));
         }
       } else if (deptTree.length > 0) {
         // PC端：清空关键字时恢复默认选中第一个根节点

--- a/packages/@steedos-widgets/amis-object/src/components/SteedosUserSelector.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/SteedosUserSelector.tsx
@@ -979,6 +979,8 @@ export const SteedosUserSelector: React.FC<UserSelectorProps> = (props) => {
           showSelectedPanel={showSelectedPanel}
           onDrillDown={handleDrillDown}
           onMobileBack={handleMobileBack}
+          onDrillBack={handleDrillBack}
+          onBackToRoot={handleBackToRoot}
           onToggleSelectedPanel={() => setShowSelectedPanel(v => !v)}
           onUserSearch={handleSearch}
           onAddUser={handleAddUser}


### PR DESCRIPTION
## 概述

将移动端 SteedosUserSelector 的导航模式从面包屑改为企业微信风格的两页式导航。

## 改动
- 初始页：通讯录入口栏 + 全部人员（递归，与PC端一致）
- 钻入页：子部门卡片 + 直属成员，标题显示当前部门名
- 左上角返回按钮替代面包屑导航
- 不影响 PC 端

Closes #536
