### PR TITLE
fix(amis-object): respect configured objectApiName at runtime in standalone app pages

### DIFF
--- a/packages/@steedos-widgets/amis-object/src/amis/AmisObjectTable.tsx
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisObjectTable.tsx
@@ -2,7 +2,7 @@
  * @Author: baozhoutao@steedos.com
  * @Date: 2022-09-01 14:44:57
  * @LastEditors: 殷亮辉 yinlianghui@hotoa.com
- * @LastEditTime: 2025-12-25 11:30:46
+ * @LastEditTime: 2026-04-29 16:40:25
  * @Description: 
  */
 import './AmisObjectTable.less';
@@ -66,9 +66,23 @@ export const AmisObjectTable = async (props) => {
       objectApiName = props.objectApiName
     }
   }else{
-    if(props.data.objectName){
-      objectApiName = props.data.objectName
+    // 优先使用组件显式配置的 objectApiName；
+    // 排除未被 amis 解析的模板字面量 "${objectName}"（出现在父级 scope 没有 objectName 时），
+    // 此时回退到 props.data.objectName，最后再回退到默认值 space_users。
+    const configuredObjectApiName =
+      props.objectApiName && props.objectApiName !== '${objectName}'
+        ? props.objectApiName
+        : undefined;
+    if(configuredObjectApiName){
+      objectApiName = configuredObjectApiName;
+    }else if(props.data?.objectName){
+      objectApiName = props.data.objectName;
     }
+    console.debug('[AmisObjectTable] resolve objectApiName', {
+      configuredObjectApiName: props.objectApiName,
+      contextObjectName: props.data?.objectName,
+      resolved: objectApiName,
+    });
   }
 
   if (crudMode) {


### PR DESCRIPTION
## 背景

[steedos/steedos-plugins#716](https://github.com/steedos/steedos-plugins/issues/716)：在「应用程序页面」类型的微页面（standalone app page，不绑定任何对象记录）中，使用微页面设计器拖入「对象表格」（`steedos-object-table`）组件后，无论组件中如何配置 `objectApiName`（如 `t1`），前台始终把它当成「人员（space_users）」渲染。

## 根因

`AmisObjectTable.tsx` 运行时分支（`!props.$$editor`）只从 `props.data.objectName` 取对象名：

```ts
let objectApiName = "space_users";

if(props.$$editor){
  if(props.objectApiName){ objectApiName = props.objectApiName }
}else{
  if(props.data.objectName){ objectApiName = props.data.objectName }
}
```

应用程序页面的父级 amis scope 不包含 `objectName`，于是回退到默认值 `space_users`，组件本身配置的 `objectApiName` 被完全忽略。

记录详情页之所以「看起来正常」，是因为元数据模板把 `objectApiName` 默认设为 `"${objectName}"`，运行时被 amis scope 中的 `objectName` 替换 — 这只是巧合。

## 改动

仅修改 `packages/@steedos-widgets/amis-object/src/amis/AmisObjectTable.tsx` 的运行时分支，把优先级改为：

**组件显式配置 `objectApiName` > 父级 scope `data.objectName` > 默认 `space_users`**

```ts
const configuredObjectApiName =
  props.objectApiName && props.objectApiName !== '${objectName}'
    ? props.objectApiName
    : undefined;
if(configuredObjectApiName){
  objectApiName = configuredObjectApiName;
}else if(props.data?.objectName){
  objectApiName = props.data.objectName;
}
```

要点：
- 显式排除未被 amis 解析的字面量 `"${objectName}"`，防止把模板字符串当成对象名去查（兼容父 scope 没有 `objectName` 的情况）。
- 设计器分支（`$$editor`）保持不变。
- `props.data.objectName` 改为可选链，避免 `props.data` 为空时报错。
- 增加一条 `console.debug` 日志，方便排查类似 “渲染了错误的对象” 的问题；用 `debug` 级避免污染默认控制台。

## 验证

本地启动 Steedos，访问应用程序页面 `http://127.0.0.1:5100/app/app_edf/page/TestAPP1`：

修复前：
- `/service/api/@space_users/uiSchema`
- GraphQL 查询 `space_users`，渲染人员列表

修复后：
- 控制台：`[AmisObjectTable] resolve objectApiName {configuredObjectApiName: "t1", resolved: "t1"}`
- `/service/api/@t1/uiSchema`
- GraphQL：`{rows:t1(filters: [], top: 20...)`，正确返回 t1 对象的 4 条记录（XX、y77、y88、p88）

## 回归覆盖

- 应用程序页面 + 显式 `objectApiName: 't1'` → 渲染 t1 ✅（已验证）
- 记录详情微页面 + `objectApiName: '${objectName}'` + `data.objectName: 'accounts'` → amis 解析后传入 `accounts`，命中第一分支 → 渲染 accounts
- 父 scope 未提供 `objectName`、`objectApiName` 也是字面量 `'${objectName}'` → 字面量被排除 → 走 `data?.objectName` → 仍是空 → 回退默认 `space_users`
- 不配 `objectApiName` 也无 `data.objectName` → 默认 `space_users`

Closes steedos/steedos-plugins#716

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>