### PR TITLE
fix(amis-object): 审批菜单 nav 401 时不再清空，鉴权头改为 Authorization Bearer

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -190,3 +190,11 @@ When fixing UI behavior issues in this repo:
 - Follow existing code patterns in the file you're modifying
 - Keep amis JSON schema generation readable (the schema objects can be very large)
 - Use lodash (`_`) for utility operations (already imported in most files)
+
+## 注释与提交说明语言
+
+- **代码注释一律使用简体中文**，包括 `//` 行注释、`/** */` JSDoc、`console.warn` / `console.debug` 中的提示文案。
+- **commit message、PR 标题与描述均使用简体中文**；commit 标题保留 Conventional Commit 前缀（如 `fix:`、`feat:`），冒号后正文用中文。
+- 仅以下内容可使用英文：标识符（变量名、函数名、类型名、文件名）、第三方 API 字段名、错误码、URL、命令示例。
+- 引用 issue / PR 时使用 `仓库#编号` 形式（例如 `steedos/steedos-plugins#668`），保证跨仓库链接可点击。
+- 修改既有英文注释时，如顺手可改为中文；不要为了改语言而批量重写无关代码。

--- a/packages/@steedos-widgets/amis-object/src/components/ApprovalTreeMenu.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/ApprovalTreeMenu.tsx
@@ -144,33 +144,14 @@ function isGridMode(): boolean {
   return false;
 }
 
-/**
- * 从 Builder.settings 或 localStorage 获取认证 token
- */
-function getAuthToken(): string | null {
+function getAuthorization(): string | null {
   try {
-    // 优先使用 Builder.settings（steedos 平台注入）
-    const builderSettings = (window as any)?.Builder?.settings;
-    if (builderSettings?.authToken) return builderSettings.authToken;
-    if (builderSettings?.['X-Auth-Token']) return builderSettings['X-Auth-Token'];
-    // 其次使用 localStorage
-    const localToken = localStorage.getItem('Meteor.loginToken') || localStorage.getItem('X-Auth-Token');
-    if (localToken) return localToken;
-  } catch {
-    // ignore
-  }
-  return null;
-}
-
-/**
- * 从 Builder.settings 或 localStorage 获取 userId
- */
-function getUserId(): string | null {
-  try {
-    const builderSettings = (window as any)?.Builder?.settings;
-    if (builderSettings?.userId) return builderSettings.userId;
-    const localUserId = localStorage.getItem('Meteor.userId');
-    if (localUserId) return localUserId;
+    const settings = (window as any)?.Builder?.settings;
+    const context = settings?.context ?? settings ?? {};
+    const tenantId = context.tenantId;
+    const authToken = context.authToken;
+    if (!tenantId || !authToken) return null;
+    return `Bearer ${tenantId},${authToken}`;
   } catch {
     // ignore
   }
@@ -969,21 +950,26 @@ export const ApprovalTreeMenu: React.FC<ApprovalTreeMenuProps> = ({
         ...customHeaders,
       };
 
-      // 自动注入认证信息
-      const token = getAuthToken();
-      const userId = getUserId();
-      if (token) reqHeaders['X-Auth-Token'] = token;
-      if (userId) reqHeaders['X-User-Id'] = userId;
+      const authorization = getAuthorization();
+      if (authorization) reqHeaders['Authorization'] = authorization;
 
       abortControllerRef.current?.abort();
       controller = new AbortController();
       abortControllerRef.current = controller;
       const res = await fetch(actualApiUrl, { headers: reqHeaders, signal: controller.signal });
+      if (!res.ok) {
+        console.warn('[ApprovalTreeMenu] nav API request failed, keeping existing menu data:', res.status);
+        return;
+      }
       const json = await res.json();
+      if (json?.errors) {
+        console.warn('[ApprovalTreeMenu] nav API returned errors, keeping existing menu data:', json.errors);
+        return;
+      }
 
       // 接口返回结构：{ data: { options: [...] }, status: 0, msg: "" }
       // 兼容多种格式：data.options 数组、data 数组、根数组
-      let items: NavItem[];
+      let items: NavItem[] | null = null;
       if (Array.isArray(json)) {
         items = json;
       } else if (Array.isArray(json?.data?.options)) {
@@ -993,7 +979,8 @@ export const ApprovalTreeMenu: React.FC<ApprovalTreeMenuProps> = ({
       } else if (Array.isArray(json?.rows)) {
         items = json.rows;
       } else {
-        items = [];
+        console.warn('[ApprovalTreeMenu] nav API returned unexpected data, keeping existing menu data:', json);
+        return;
       }
       setNavItems(items);
 


### PR DESCRIPTION
关联 steedos/steedos-plugins#668

## 问题
审批中心左侧菜单偶发空白：`/api/v6/services/workflow/nav` 接口返回 401（Unauthorized），`ApprovalTreeMenu` 在解析失败时把 `items` 重置为 `[]`，并把空数组写回 amis tree，菜单瞬时变空白。

根因有两点：
1. `fetchNav` 用旧的 `X-Auth-Token` / `X-User-Id` / `Meteor.loginToken` / `localStorage` 多源拼装鉴权头，部分场景拿不到正确 token，被服务端判为未登录。
2. nav 接口非 200 / 含 errors / 数据结构异常时，前端用空数组覆盖菜单，没有兜底守卫。

## 改动
仅前端，文件 `packages/@steedos-widgets/amis-object/src/components/ApprovalTreeMenu.tsx`：

- 新增 `getAuthorization()`：从 `(window as any).Builder.settings.context ?? settings` 取 `tenantId` 与 `authToken`，统一返回 `Bearer <tenantId>,<authToken>`，与 amis-lib `steedos.client.js` 鉴权来源对齐。
- 移除 `getAuthToken()` / `getUserId()` 与 `X-Auth-Token` / `X-User-Id` header 注入。
- nav 请求失败时新增三道守卫，命中即 `console.warn` 后 `return`，不再覆盖既有菜单：
  - `!res.ok`
  - `json?.errors`
  - 异常数据结构（原本 fallback 为 `items = []`）

附带：在 `.github/copilot-instructions.md` 追加注释与提交说明的中文语言规范。

## 验证（Chrome DevTools）
复现规则：劫持 `fetch`，对 `/workflow/nav` 强制 `credentials: 'omit'`，使其返回 401。

| 版本 | nav 状态 | treeItemCount | 菜单表现 |
|---|---|---|---|
| 未修基线 | 401 | 0 | 空白 ❌ |
| 本 PR | 200 | 11 | 完整 ✅ |
| 本 PR + `context.authToken='invalid-token'` 强制坏 token | 401 | 11 | 完整（兜底守卫生效）✅ |

构建：在仓库根目录 `yarn build-object` 通过；`dist/amis-object.umd.js` 已含新 `getAuthorization` / 守卫日志。

## 风险
- 鉴权头切换后，仅依赖旧 `X-Auth-Token` 的极旧服务端版本不再受支持；当前 platform 3.0 服务端 `requireAuthentication` 已同时支持 `Authorization: Bearer`，本仓库 6.10 配套使用，无影响。
- 守卫策略只是「不覆盖」，不会自动重试；初次进入页面 nav 就 401 时，菜单仍然为空，等下一次正常返回填充。

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>