### PR TITLE
fix: 修复 xlsx/docx 预览关闭后切换审批单触发整页刷新 (#702)

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/workflow/attachment.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/attachment.js
@@ -17,11 +17,22 @@ const AmisOfficeViewer = ({ src }) => {
         if (ref.current) {
             let amis = window.amisRequire && window.amisRequire('amis/embed');
             if (amis && amis.embed) {
-                scope = amis.embed(ref.current, {
-                    type: 'office-viewer',
-                    src: src,
-                    className: 'w-full h-full'
-                });
+                // 使用独立 session 避免污染全局 amis env。
+                // amis-core 的 AMISRenderer 在已有同名 session 时会通过 Object.assign 覆盖现有 env 的
+                // jumpTo/updateLocation/isCurrentUrl 等导航处理函数，从而把外层页面 SPA 友好的
+                // 导航实现替换成 sdk 默认的 location.href，导致预览关闭后切换审批单触发整页刷新。
+                // 详见 steedos/steedos-plugins#702。
+                const session = 'steedos-office-viewer-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
+                scope = amis.embed(
+                    ref.current,
+                    {
+                        type: 'office-viewer',
+                        src: src,
+                        className: 'w-full h-full'
+                    },
+                    null,
+                    { session: session }
+                );
             }
         }
         return () => {


### PR DESCRIPTION
## 问题

steedos/steedos-plugins#702

打开审批单中的 xlsx/docx 附件预览，关闭预览弹窗后，再切换到另一张审批单时浏览器会触发整页刷新（`location.href` 跳转），而不是正常的 SPA 路由切换。pdf/图片等其他附件类型不受影响。

## 根因

`packages/@steedos-widgets/amis-lib/src/workflow/attachment.js` 中的 `AmisOfficeViewer` 调用 `amis.embed(container, schema)` 时未指定 `session`，默认使用 `'global'` session。

`amis-core` 的 `AMISRenderer`（`amis-core/lib/index.js` ~L175-188）在已有同名 session 时，会走"复用 store"分支并通过 `Object.assign(env, options)` 把传入的 env 字段**覆盖**现有 env：

```js
var store = factory.stores[options.session || 'global'];
if (!store) { /* 创建新 env */ }
else { Object.assign(env, { jumpTo, updateLocation, isCurrentUrl, fetcher, notify, alert, confirm, ... }); }
```

`amis.embed` 内部使用 sdk 默认 env（`jumpTo` 实现是 `location.href = to` / `window.location.replace(to)`，见 `amis-core/lib/factory.js` ~L324-352），结果就是外层页面 SPA 友好的 `jumpTo/updateLocation/isCurrentUrl` 等被默认实现覆盖。预览关闭后这些被污染的处理函数还留在全局 store 里，下次 SPA 路由切换走到 `jumpTo` 时就触发了整页刷新。

## 修复

为 `amis.embed` 传入唯一的 `session` key，让 amis 创建独立的 RendererStore，不再触碰全局 env：

```js
const session = 'steedos-office-viewer-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
amis.embed(container, schema, null, { session });
```

最小化改动，仅一个文件。

## 验证

本地启动 steedos-plugins dev server + widgets dist server，用 Playwright 复现并验证：

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| xlsx 预览→关闭→切换审批单 | 整页刷新（probe 丢失，beforeunload 触发，`location.href` 被赋值） | SPA 切换（probe 保留，push=1，bu=0，hrefSet=0）✅ |
| docx 预览→关闭→切换审批单 | 整页刷新 | SPA 切换 ✅ |
| pdf 预览→关闭→切换审批单（回归） | SPA 切换 | SPA 切换 ✅ |

## 影响范围

仅影响 `AmisOfficeViewer`（office-viewer 嵌入）的 amis 实例隔离，不改变其它 amis 行为。改动是纯加法（加了一个隔离参数），不修改任何已有逻辑。