### PR TITLE
fix(#631): 优化老版审批表单只读字段和分组样式

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -986,11 +986,11 @@ const getFormMobileView = async (instance, tableFieldMap) => {
       // 手机端字段渲染：只读态使用浅灰边框 + 圆角，编辑态使用浅黄背景 + 浅灰边框
       const isEditableField = field.permission === 'editable';
 
-      // Label 样式：16px font-semibold(600) + #444 匹配标准记录详细页风格
+      // Label 样式：16px font-weight 400 (与字段值同字号、不加粗)；分组标题靠 .mobile-section-title 加粗区分
       const labelTpl = {
         type: "tpl",
         className: "block text-left px-0",
-        tpl: `<div class="font-semibold" style="font-size: 16px; color: #444; padding-top: 7px; margin-bottom: 4px;">${
+        tpl: `<div style="font-size: 16px; font-weight: 400; color: #444; padding-top: 7px; margin-bottom: 4px;">${
           field.name || field.code
         } ${field.is_required ? '<span class="text-red-500">*</span>' : ''}</div>`,
       };

--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -986,11 +986,12 @@ const getFormMobileView = async (instance, tableFieldMap) => {
       // 手机端字段渲染：只读态使用浅灰边框 + 圆角，编辑态使用浅黄背景 + 浅灰边框
       const isEditableField = field.permission === 'editable';
 
-      // Label 样式：16px font-weight 400 (与字段值同字号、不加粗)；分组标题靠 .mobile-section-title 加粗区分
+      // Label 样式：16px font-weight 500（medium，比字段值 400 略明显一档）
+      // 字重层级：顶部标题 700 → 分组 600 → label 500 → 字段值 400，逐级递减
       const labelTpl = {
         type: "tpl",
         className: "block text-left px-0",
-        tpl: `<div style="font-size: 16px; font-weight: 400; color: #444; padding-top: 7px; margin-bottom: 4px;">${
+        tpl: `<div style="font-size: 16px; font-weight: 500; color: #444; padding-top: 7px; margin-bottom: 4px;">${
           field.name || field.code
         } ${field.is_required ? '<span class="text-red-500">*</span>' : ''}</div>`,
       };

--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -837,7 +837,7 @@ const getTdField = async (field, fieldsCount, tableFieldMap) => {
     background: field.permission !== "editable" ? "#FFFFFF" : "rgba(255, 251, 235, 0.8)",
     colspan: (field.type === "table" || field.type === "html" || field.config?.type === 'html') ? 4 : 3 - (fieldsCount - 1) * 2,
     align: "left",
-    className: "td-field",
+    className: `td-field ${field.permission === "editable" ? "td-field-editable" : "td-field-readonly"}`,
     width: "32%",
     body: [await getTdInputTpl(field, null, false, tableFieldMap)],
     style: {
@@ -983,10 +983,8 @@ const getFormMobileView = async (instance, tableFieldMap) => {
         inputTpl.className = inputTpl.className.replace(/m-none|p-none/g, '').trim();
       }
 
-      // 手机端只读态优化：如果是 static 类型，可能还是原来的样式，确保可读性
-      if(inputTpl.type && inputTpl.type.startsWith('static')){
-         // 可以追加一些样式
-      }
+      // 手机端字段渲染：只读态使用浅灰边框 + 圆角，编辑态使用浅黄背景 + 浅灰边框
+      const isEditableField = field.permission === 'editable';
 
       // Label 样式：16px font-semibold(600) + #444 匹配标准记录详细页风格
       const labelTpl = {
@@ -1004,11 +1002,11 @@ const getFormMobileView = async (instance, tableFieldMap) => {
             labelTpl, 
             {
                 type: "container",
-                className: field.permission === 'editable' ? "px-2 mobile-editable-field" : "px-0", // Input container padding
+                className: isEditableField ? "px-2 mobile-editable-field" : "mobile-readonly-field",
                 style: {
-                    backgroundColor: field.permission === 'editable' ? "rgba(255, 251, 235, 0.8)" : "#ffffff",
-                    border: field.permission === 'editable' ? "1px solid #d1d5db" : "none",
-                    borderRadius: field.permission === 'editable' ? "8px" : "0"
+                    backgroundColor: isEditableField ? "rgba(255, 251, 235, 0.8)" : "#ffffff",
+                    border: "1px solid " + (isEditableField ? "#d1d5db" : "#e5e7eb"),
+                    borderRadius: isEditableField ? "8px" : "6px"
                 },
                 body: [inputTpl]
             }

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -70,15 +70,20 @@
     // 移动端 Section 分组标题（shadcn/ui 风格）
     // 上方细线分隔 + 标题 + 可选描述文字
     // ========================================================
+    // ========================================================
+    // 移动端 Section 分组标题（向新版 workflow-form-v2 H3 看齐）
+    // 13px font-semibold + #1f2937，仅靠间距分组，不画上边框
+    // ========================================================
     .mobile-section-divider {
-        border-top: 1px solid #e5e7eb; // gray-200 separator line
-        padding-top: 12px !important;
+        padding-top: 0 !important;
+        margin-top: 16px !important;
+        margin-bottom: 4px !important;
 
         .mobile-section-header {
             .mobile-section-title {
-                font-size: 14px;
+                font-size: 13px;
                 font-weight: 600;
-                color: #0f172a; // slate-900
+                color: #1f2937; // gray-800 与新版 H3 一致
                 line-height: 1.4;
                 letter-spacing: -0.01em;
             }
@@ -959,9 +964,11 @@
             margin-bottom: 12px !important; /* 与下方表单分隔，避免挤压 */
         }
 
-        /* 底部提交人区域优化 */
+        /* 底部提交人区域优化 - 向新版 workflow-form-v2 看齐：
+           左右两栏 flex 布局，提交日期右贴齐；字号 13px 灰色；左右 16px 留白 */
         .instance-applicant-view {
             border: none !important;
+            margin-top: 8px;
 
             td {
                 border: none !important;
@@ -972,20 +979,44 @@
                 display: flex !important;
                 flex-direction: row;
                 flex-wrap: nowrap;
+                align-items: center;
+                padding: 8px 16px !important;
+                gap: 8px;
             }
 
             td {
                 display: flex !important;
                 align-items: center !important;
                 flex-wrap: nowrap;
-                padding-left: 6px;
+                padding: 0 !important;
                 white-space: nowrap;
+                font-size: 13px;
+                color: #6b7280; // gray-500，标签灰
 
                 /* 取消 inline-left 的 float，改由 flex 控制排列 */
                 .inline-left {
                     float: none !important;
                     display: inline-block !important;
                 }
+
+                /* 值文本（人名 / 日期）颜色加深 */
+                .antd-TplField:last-child {
+                    color: #1f2937; // gray-800
+                }
+            }
+
+            /* 第一列（提交人）占据剩余空间，文本可截断 */
+            td:first-child {
+                flex: 1 1 auto !important;
+                min-width: 0;
+                justify-content: flex-start;
+            }
+
+            /* 第二列（提交日期）右贴齐 */
+            td:last-child {
+                flex: 0 0 auto !important;
+                margin-left: auto;
+                justify-content: flex-end;
             }
         }
 

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -81,7 +81,7 @@
 
         .mobile-section-header {
             .mobile-section-title {
-                font-size: 13px;
+                font-size: 16px; // 与字段 label 同字号，靠加粗区分
                 font-weight: 600;
                 color: #1f2937; // gray-800 与新版 H3 一致
                 line-height: 1.4;
@@ -315,10 +315,11 @@
 // ========================================================
 // 移动端只读字段（.mobile-readonly-field）样式
 // 浅灰边框 + 6px 圆角 + 内边距，参考新版 workflow-form-v2 的视觉
+// 字段值字号 16px（与字段 label 同大），消除 antd-Form-static / antd-Form-control
+// 内部不一致的 padding/line-height，保证所有只读字段框高度一致
 // ========================================================
 .steedos-amis-instance-view .instance-form-view-mobile .mobile-readonly-field {
     padding: 6px 12px !important;
-    min-height: 38px;
     box-sizing: border-box;
 
     > div {
@@ -337,13 +338,17 @@
         }
     }
 
-    // 只读值容器去掉默认 padding/border
+    // 只读值容器：统一 padding/line-height/font，避免不同字段类型造成的高度差异
     .antd-Form-value,
-    .antd-Form-static.antd-Form-control {
+    .antd-Form-static,
+    .antd-Form-control,
+    .antd-PlainField {
         padding: 0 !important;
+        margin: 0 !important;
         border-bottom: none !important;
         background: transparent !important;
-        font-size: 13px;
+        font-size: 16px;
+        font-weight: 400;
         color: #1f2937;
         line-height: 1.6;
     }

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -72,19 +72,19 @@
     // ========================================================
     .mobile-section-divider {
         border-top: 1px solid #e5e7eb; // gray-200 separator line
-        padding-top: 16px !important;
+        padding-top: 12px !important;
 
         .mobile-section-header {
             .mobile-section-title {
-                font-size: 16px;
+                font-size: 14px;
                 font-weight: 600;
                 color: #0f172a; // slate-900
-                line-height: 1.5;
+                line-height: 1.4;
                 letter-spacing: -0.01em;
             }
 
             .mobile-section-desc {
-                font-size: 14px;
+                font-size: 12px;
                 font-weight: 400;
                 color: #64748b; // slate-500
                 line-height: 1.4;
@@ -294,6 +294,54 @@
     &:has(.tox-tinymce) {
         padding-left: 0 !important;
         padding-right: 0 !important;
+    }
+}
+
+// ========================================================
+// 移动端只读字段（.mobile-readonly-field）样式
+// 浅灰边框 + 6px 圆角 + 内边距，参考新版 workflow-form-v2 的视觉
+// ========================================================
+.steedos-amis-instance-view .instance-form-view-mobile .mobile-readonly-field {
+    padding: 6px 12px !important;
+    min-height: 38px;
+    box-sizing: border-box;
+
+    > div {
+        width: 100% !important;
+    }
+
+    // Form-item 去掉底线、内边距，避免框内再出现一条线
+    .antd-Form-item,
+    .steedos-field-input-readonly {
+        min-height: auto !important;
+        padding: 0 !important;
+        margin: 0 !important;
+        border-bottom: none !important;
+        &::after {
+            content: none !important;
+        }
+    }
+
+    // 只读值容器去掉默认 padding/border
+    .antd-Form-value,
+    .antd-Form-static.antd-Form-control {
+        padding: 0 !important;
+        border-bottom: none !important;
+        background: transparent !important;
+        font-size: 13px;
+        color: #1f2937;
+        line-height: 1.6;
+    }
+}
+
+// 在 768px 媒体查询里，.antd-Form-item 被加了 1px 底线，
+// 在只读字段框内需要覆盖回去，避免框中间出现多余的横线
+@media (max-width: 768px) {
+    .steedos-amis-instance-view .instance-form-view-mobile .mobile-readonly-field .antd-Form-item {
+        border-bottom: none !important;
+        &::after {
+            content: none !important;
+        }
     }
 }
 

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -72,7 +72,7 @@
     // ========================================================
     // ========================================================
     // 移动端 Section 分组标题（向新版 workflow-form-v2 H3 看齐）
-    // 13px font-semibold + #1f2937，仅靠间距分组，不画上边框
+    // 13px font-semibold + #1f2937 + 标题下方加 2px gray-400 分隔线
     // ========================================================
     .mobile-section-divider {
         padding-top: 0 !important;
@@ -86,6 +86,7 @@
                 color: #1f2937; // gray-800 与新版 H3 一致
                 line-height: 1.4;
                 letter-spacing: -0.01em;
+                margin-bottom: 4px;
             }
 
             .mobile-section-desc {
@@ -94,6 +95,15 @@
                 color: #64748b; // slate-500
                 line-height: 1.4;
                 margin-top: 2px;
+            }
+
+            // 新版 H3 后紧跟一个 border-bottom:2px solid #9ca3af 的空 div 作为下线
+            // 老版没法在 JS 里塞节点，用 ::after 伪元素模拟相同视觉
+            &::after {
+                content: "";
+                display: block;
+                border-bottom: 2px solid #9ca3af; // gray-400 与新版一致
+                margin-top: 4px;
             }
         }
     }
@@ -991,7 +1001,8 @@
                 padding: 0 !important;
                 white-space: nowrap;
                 font-size: 13px;
-                color: #6b7280; // gray-500，标签灰
+                font-weight: 500; // 与新版 label font-medium 对齐
+                color: #374151; // gray-700 与新版 label 一致
 
                 /* 取消 inline-left 的 float，改由 flex 控制排列 */
                 .inline-left {
@@ -999,8 +1010,15 @@
                     display: inline-block !important;
                 }
 
-                /* 值文本（人名 / 日期）颜色加深 */
+                /* Label：第一个 .antd-TplField (含"提交人：" / "提交日期：") */
+                > .antd-TplField:first-child {
+                    font-weight: 500;
+                    color: #374151; // gray-700
+                }
+
+                /* 值文本（人名 / 日期）颜色加深、weight 回归 normal */
                 .antd-TplField:last-child {
+                    font-weight: 400;
                     color: #1f2937; // gray-800
                 }
             }

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -980,7 +980,8 @@
         }
 
         /* 底部提交人区域优化 - 向新版 workflow-form-v2 看齐：
-           左右两栏 flex 布局，提交日期右贴齐；字号 13px 灰色；左右 16px 留白 */
+           左右两栏 flex 布局，提交日期右贴齐；字号与表单字段一致 16px；
+           字重 label 500 / value 400 与表单字段层级一致 */
         .instance-applicant-view {
             border: none !important;
             margin-top: 8px;
@@ -1005,9 +1006,9 @@
                 flex-wrap: nowrap;
                 padding: 0 !important;
                 white-space: nowrap;
-                font-size: 13px;
-                font-weight: 500; // 与新版 label font-medium 对齐
-                color: #374151; // gray-700 与新版 label 一致
+                font-size: 16px; // 与表单字段同字号
+                font-weight: 500; // label 字重 medium，与表单字段 label 对齐
+                color: #374151; // gray-700
 
                 /* 取消 inline-left 的 float，改由 flex 控制排列 */
                 .inline-left {
@@ -1017,12 +1018,14 @@
 
                 /* Label：第一个 .antd-TplField (含"提交人：" / "提交日期：") */
                 > .antd-TplField:first-child {
+                    font-size: 16px;
                     font-weight: 500;
-                    color: #374151; // gray-700
+                    color: #444; // 与表单字段 label 颜色一致
                 }
 
-                /* 值文本（人名 / 日期）颜色加深、weight 回归 normal */
+                /* 值文本（人名 / 日期）：weight 回归 normal、字号同 16px */
                 .antd-TplField:last-child {
+                    font-size: 16px;
                     font-weight: 400;
                     color: #1f2937; // gray-800
                 }


### PR DESCRIPTION
## 背景

源问题：steedos/steedos-plugins#707  
实现 issue：#631

老版审批单（无 `formVersion.version === 'v2'`）在手机端的只读字段没有边框/圆角，视觉与新版 `workflow-form-v2` 反差较大；section 分组标题字号偏大、留白偏多。

参考新版样式（`border border-gray-200 rounded-md px-3 py-2 text-[13px] min-h-[38px]`）做对齐。

## 改动

`packages/@steedos-widgets/amis-lib/src/workflow/flow.js`
- `getFormMobileView`：只读字段容器新增 className `mobile-readonly-field`，加 `1px solid #e5e7eb` + `border-radius: 6px` + 白底；编辑态保持原 `mobile-editable-field` 的浅黄背景 + 浅灰边框 + 8px 圆角，方便区分两种态。
- `getTdField`：PC 端 td 增加 `td-field-editable` / `td-field-readonly` className 标记（本次未改 PC 视觉，留作后续扩展）。
- 移除 `getFormMobileView` 内空的 `if(inputTpl.type.startsWith('static')) {}` 占位块。

`packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less`
- 新增 `.mobile-readonly-field` 样式：`padding: 6px 12px; min-height: 38px;`；内部覆盖 `.antd-Form-item / .steedos-field-input-readonly / .antd-Form-value / .antd-Form-static.antd-Form-control` 的 `padding/border-bottom`，避免框内出现多余横线。
- 在 `@media (max-width: 768px)` 里再覆盖一次 `.mobile-readonly-field .antd-Form-item { border-bottom: none !important; }`，避免该媒体查询里给所有 Form-item 加的 1px 底线让只读框中间多一条线。
- `.mobile-section-divider`：标题字号 16→14、描述 14→12、padding-top 16→12，更紧凑接近新版。

## 验证

- ✅ `yarn build-object` 成功（amis-lib + amis-object 两个包）。
- ⚠️ 浏览器手机端回归：本地 5100 服务在改动期间 `/accounts/settings` 返回 500/超时，无法登录复测。代码改动仅作用于 `formVersion !== 'v2'` 的老版分支，不会影响新版 `workflow-form-v2`。
- 建议合并前在本地老版表单（如 `instance_tasks/view/...`）和新版表单（`instances/view/...`）各跑一次手机端回归。

## 风险

- `.mobile-readonly-field` 是新 className，不会污染既有选择器；编辑态走的是原有的 `.mobile-editable-field`，未改其样式。
- `getTdField` 的 className 拼接保留了原 `td-field`，仅追加新标记，PC 端表格视觉不变。

Refs: steedos-plugins#707, #631