### PR TITLE
fix(#633): 老版审批表单移动端样式优化 — 字体/间距/签字字段对齐新版

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -833,11 +833,14 @@ const getTdInputTpl = async (field, label, inTable=false, tableFieldMap) => {
 };
 
 const getTdField = async (field, fieldsCount, tableFieldMap) => {
+  // 签字字段（approval_comments）虽然 permission=editable，但用户不能直接编辑，视觉上按只读处理
+  const isSignField = field.config?.type === 'approval_comments';
+  const showAsEditable = field.permission === "editable" && !isSignField;
   return {
-    background: field.permission !== "editable" ? "#FFFFFF" : "rgba(255, 251, 235, 0.8)",
+    background: showAsEditable ? "rgba(255, 251, 235, 0.8)" : "#FFFFFF",
     colspan: (field.type === "table" || field.type === "html" || field.config?.type === 'html') ? 4 : 3 - (fieldsCount - 1) * 2,
     align: "left",
-    className: `td-field ${field.permission === "editable" ? "td-field-editable" : "td-field-readonly"}`,
+    className: `td-field ${showAsEditable ? "td-field-editable" : "td-field-readonly"}`,
     width: "32%",
     body: [await getTdInputTpl(field, null, false, tableFieldMap)],
     style: {
@@ -984,8 +987,9 @@ const getFormMobileView = async (instance, tableFieldMap) => {
       }
 
       // 手机端字段渲染：只读态使用浅灰边框 + 圆角，编辑态使用浅黄背景 + 浅灰边框
-      // 签字字段的可编辑背景色由 CSS :has(.instance-sign) 覆盖为只读视觉
-      const isEditableField = field.permission === 'editable';
+      // 签字字段（approval_comments）虽然 permission=editable，但用户不能直接编辑，视觉上按只读处理
+      const isSignField = field.config?.type === 'approval_comments';
+      const isEditableField = field.permission === 'editable' && !isSignField;
 
       // Label 样式：13px font-weight 500 — 对齐新版 workflow-form-v2 字段 label
       // 字重层级：顶部标题 700 → 分组 600 → label 500 → 字段值 400，逐级递减

--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -984,6 +984,7 @@ const getFormMobileView = async (instance, tableFieldMap) => {
       }
 
       // 手机端字段渲染：只读态使用浅灰边框 + 圆角，编辑态使用浅黄背景 + 浅灰边框
+      // 签字字段的可编辑背景色由 CSS :has(.instance-sign) 覆盖为只读视觉
       const isEditableField = field.permission === 'editable';
 
       // Label 样式：13px font-weight 500 — 对齐新版 workflow-form-v2 字段 label

--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -971,7 +971,7 @@ const getFormMobileView = async (instance, tableFieldMap) => {
                   className: "block w-full text-left"
                 }
               ],
-              className: "mobile-section-divider mt-6 mb-2 px-0"
+              className: "mobile-section-divider mt-3 mb-1 px-0"
           });
           continue;
       }
@@ -986,12 +986,12 @@ const getFormMobileView = async (instance, tableFieldMap) => {
       // 手机端字段渲染：只读态使用浅灰边框 + 圆角，编辑态使用浅黄背景 + 浅灰边框
       const isEditableField = field.permission === 'editable';
 
-      // Label 样式：16px font-weight 500（medium，比字段值 400 略明显一档）
+      // Label 样式：13px font-weight 500 — 对齐新版 workflow-form-v2 字段 label
       // 字重层级：顶部标题 700 → 分组 600 → label 500 → 字段值 400，逐级递减
       const labelTpl = {
         type: "tpl",
         className: "block text-left px-0",
-        tpl: `<div style="font-size: 16px; font-weight: 500; color: #444; padding-top: 7px; margin-bottom: 4px;">${
+        tpl: `<div style="font-size: 13px; font-weight: 500; color: #444; padding-top: 0; margin-bottom: 4px;">${
           field.name || field.code
         } ${field.is_required ? '<span class="text-red-500">*</span>' : ''}</div>`,
       };

--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -998,7 +998,7 @@ const getFormMobileView = async (instance, tableFieldMap) => {
 
       body.push({
         type: "container",
-        className: "bg-white text-left",
+        className: "bg-white text-left mobile-field-card",
         body: [
             labelTpl, 
             {

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -366,6 +366,19 @@
     }
 }
 
+// 签字字段虽然 permission=editable，但用户不能直接编辑（由审批栏自动带入），
+// 检测到 .mobile-editable-field 内含 .instance-sign 时覆盖为只读视觉：去掉黄色背景
+.steedos-amis-instance-view .instance-form-view-mobile .mobile-editable-field:has(.instance-sign) {
+    background-color: #ffffff !important;
+    border-color: #e5e7eb !important;
+    border-radius: 6px !important;
+
+    .instance-sign-content {
+        margin-top: 2px !important;
+        margin-bottom: 2px !important;
+    }
+}
+
 // 在 768px 媒体查询里，.antd-Form-item 被加了 1px 底线，
 // 在只读字段框内需要覆盖回去，避免框中间出现多余的横线
 @media (max-width: 768px) {

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -366,19 +366,6 @@
     }
 }
 
-// 签字字段虽然 permission=editable，但用户不能直接编辑（由审批栏自动带入），
-// 检测到 .mobile-editable-field 内含 .instance-sign 时覆盖为只读视觉：去掉黄色背景
-.steedos-amis-instance-view .instance-form-view-mobile .mobile-editable-field:has(.instance-sign) {
-    background-color: #ffffff !important;
-    border-color: #e5e7eb !important;
-    border-radius: 6px !important;
-
-    .instance-sign-content {
-        margin-top: 2px !important;
-        margin-bottom: 2px !important;
-    }
-}
-
 // 在 768px 媒体查询里，.antd-Form-item 被加了 1px 底线，
 // 在只读字段框内需要覆盖回去，避免框中间出现多余的横线
 @media (max-width: 768px) {

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -313,6 +313,12 @@
 }
 
 // ========================================================
+// 移动端字段卡片之间的垂直间距 - 与新版 space-y-3 (12px) 对齐
+// ========================================================
+.steedos-amis-instance-view .instance-form-view-mobile .mobile-field-card {
+    margin-bottom: 12px;
+}
+// ========================================================
 // 移动端只读字段（.mobile-readonly-field）样式
 // 浅灰边框 + 6px 圆角 + 内边距，参考新版 workflow-form-v2 的视觉
 // 字段值字号 16px（与字段 label 同大），消除 antd-Form-static / antd-Form-control

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -357,6 +357,13 @@
         color: #1f2937;
         line-height: 1.5;
     }
+
+    // 只读签字字段：内部 .instance-sign-content 自带 m-2.5 (10px) 上下外边距，
+    // 在移动端只读卡片中显得过高，压到 2px 让空签字框与普通字段高度接近
+    .instance-sign-content {
+        margin-top: 2px !important;
+        margin-bottom: 2px !important;
+    }
 }
 
 // 在 768px 媒体查询里，.antd-Form-item 被加了 1px 底线，

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -76,17 +76,17 @@
     // ========================================================
     .mobile-section-divider {
         padding-top: 0 !important;
-        margin-top: 16px !important;
-        margin-bottom: 4px !important;
+        margin-top: 12px !important; // 上方间距 12px
+        margin-bottom: 12px !important; // 下方间距 12px，与字段间距一致
 
         .mobile-section-header {
             .mobile-section-title {
-                font-size: 16px; // 与字段 label 同字号，靠加粗区分
+                font-size: 13px; // 对齐新版 workflow-form-v2 分组标题 H3
                 font-weight: 600;
                 color: #1f2937; // gray-800 与新版 H3 一致
                 line-height: 1.4;
                 letter-spacing: -0.01em;
-                margin-bottom: 4px;
+                margin-bottom: 4px; // 标题文字到分隔线的间距
             }
 
             .mobile-section-desc {
@@ -97,13 +97,12 @@
                 margin-top: 2px;
             }
 
-            // 新版 H3 后紧跟一个 border-bottom:2px solid #9ca3af 的空 div 作为下线
-            // 老版没法在 JS 里塞节点，用 ::after 伪元素模拟相同视觉
+            // 标题下方分隔线，对齐新版 workflow-form-v2 的 border-b-2 #9ca3af
+            // 用 ::after 模拟新版的 sibling div 视觉效果
             &::after {
                 content: "";
                 display: block;
                 border-bottom: 2px solid #9ca3af; // gray-400 与新版一致
-                margin-top: 4px;
             }
         }
     }
@@ -321,7 +320,7 @@
 // ========================================================
 // 移动端只读字段（.mobile-readonly-field）样式
 // 浅灰边框 + 6px 圆角 + 内边距，参考新版 workflow-form-v2 的视觉
-// 字段值字号 16px（与字段 label 同大），消除 antd-Form-static / antd-Form-control
+// 字段值字号 13px（与新版 workflow-form-v2 对齐），消除 antd-Form-static / antd-Form-control
 // 内部不一致的 padding/line-height，保证所有只读字段框高度一致
 // ========================================================
 .steedos-amis-instance-view .instance-form-view-mobile .mobile-readonly-field {
@@ -353,10 +352,10 @@
         margin: 0 !important;
         border-bottom: none !important;
         background: transparent !important;
-        font-size: 16px;
+        font-size: 13px; // 对齐新版 workflow-form-v2 字段值字号
         font-weight: 400;
         color: #1f2937;
-        line-height: 1.6;
+        line-height: 1.5;
     }
 }
 
@@ -381,6 +380,14 @@
     top: -13px;
     background: #fff;
     z-index: 999;
+}
+
+// 移动端审批标题：对齐新版 workflow-form-v2 的 text-[15px] font-bold
+@media (max-width: 768px) {
+    .steedos-amis-instance-view .instance-name {
+        font-size: 15px;
+        font-weight: 700;
+    }
 }
 
 .steedos-amis-instance-view .instance-form-view{
@@ -845,18 +852,18 @@
             .cxd-Panel-title,
             .antd-Panel-title,
             .antd-List-heading {
-                font-size: 16px !important;
+                font-size: 15px !important;
                 font-weight: 600 !important;
-                line-height: 24px !important;
+                line-height: 22px !important;
                 color: #374151 !important; /* text-gray-700 */
             }
 
             .instance-scrollable-list {
                 a.text-base,
                 button.text-base {
-                    font-size: 16px !important;
+                    font-size: 13px !important;
                     font-weight: 400 !important;
-                    line-height: 24px !important;
+                    line-height: 20px !important;
                 }
             }
 
@@ -876,9 +883,9 @@
                     
                     /* 统一标题字体 */
                     &.antd-List-heading {
-                        font-size: 16px !important;
+                        font-size: 15px !important;
                         font-weight: 600 !important;
-                        line-height: 24px !important;
+                        line-height: 22px !important;
                         color: #374151 !important; /* text-gray-700 */
                     }
                 }
@@ -920,17 +927,17 @@
                 text-align: left !important;
                 font-weight: 600 !important;
                 border: none !important;
-                font-size: 16px !important;
-                line-height: 24px !important;
+                font-size: 15px !important;
+                line-height: 22px !important;
                 color: #374151 !important; /* text-gray-700 */
             }
 
             .instance-scrollable-list {
                 a.text-base,
                 button.text-base {
-                    font-size: 16px !important;
+                    font-size: 13px !important;
                     font-weight: 400 !important;
-                    line-height: 24px !important;
+                    line-height: 20px !important;
                 }
             }
 
@@ -952,9 +959,9 @@
                     display: block; 
                     text-align: left;
                     color: #374151; /* text-gray-700 */
-                    font-size: 16px;
+                    font-size: 13px;
                     font-weight: 400;
-                    line-height: 24px;
+                    line-height: 20px;
                     &:hover {
                         color: #2563eb; /* text-blue-600 */
                         text-decoration: underline;
@@ -978,15 +985,32 @@
             }
         }
 
-        /* 相关台账信息区域：与附件/相关文件统一左内边距，但保留原有链接样式与点击区域 */
+        /* 相关台账信息区域：与附件/相关文件统一左内边距和字号 */
         .instance-related-records {
             padding-left: 8px !important;
             padding-right: 8px !important;
             margin-bottom: 12px !important; /* 与下方表单分隔，避免挤压 */
+
+            /* 标题 */
+            .cxd-Panel-title,
+            .antd-Panel-title,
+            .cxd-List-heading,
+            .antd-List-heading {
+                font-size: 15px !important;
+                font-weight: 600 !important;
+                line-height: 22px !important;
+                color: #374151 !important;
+            }
+
+            /* 链接列表项 */
+            a {
+                font-size: 13px;
+                line-height: 20px;
+            }
         }
 
         /* 底部提交人区域优化 - 向新版 workflow-form-v2 看齐：
-           左右两栏 flex 布局，提交日期右贴齐；字号与表单字段一致 16px；
+           左右两栏 flex 布局，提交日期右贴齐；字号与表单字段一致 13px；
            字重 label 500 / value 400 与表单字段层级一致 */
         .instance-applicant-view {
             border: none !important;
@@ -1002,7 +1026,7 @@
                 flex-direction: row;
                 flex-wrap: nowrap;
                 align-items: center;
-                padding: 8px 16px !important;
+                padding: 8px 8px !important; // 水平 8px 对齐表单卡片左右边距
                 gap: 8px;
             }
 
@@ -1012,7 +1036,7 @@
                 flex-wrap: nowrap;
                 padding: 0 !important;
                 white-space: nowrap;
-                font-size: 16px; // 与表单字段同字号
+                font-size: 13px; // 与表单字段同字号
                 font-weight: 500; // label 字重 medium，与表单字段 label 对齐
                 color: #374151; // gray-700
 
@@ -1024,14 +1048,14 @@
 
                 /* Label：第一个 .antd-TplField (含"提交人：" / "提交日期：") */
                 > .antd-TplField:first-child {
-                    font-size: 16px;
+                    font-size: 13px;
                     font-weight: 500;
                     color: #444; // 与表单字段 label 颜色一致
                 }
 
-                /* 值文本（人名 / 日期）：weight 回归 normal、字号同 16px */
+                /* 值文本（人名 / 日期）：weight 回归 normal、字号同 13px */
                 .antd-TplField:last-child {
-                    font-size: 16px;
+                    font-size: 13px;
                     font-weight: 400;
                     color: #1f2937; // gray-800
                 }


### PR DESCRIPTION
# 老版审批表单移动端样式优化

关联 Issue: #633

本分支只动了 2 个文件：
- `packages/@steedos-widgets/amis-lib/src/workflow/flow.js`
- `packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less`

## 解决的问题

### 1. 移动端字体统一（对齐新版 workflow-form-v2）

| 元素 | 改前 | 改后 |
|---|---|---|
| 顶部审批标题 | 20px / 700 | **15px** / 700 |
| 分组标题 | 16px / 600 | **13px** / 600 |
| 字段 label | 16px / 500 | **13px** / 500 |
| 字段值 | 16px / 400 | **13px** / 400 |
| 提交人/提交日期 | 16px | **13px** |
| 附件/相关文件区域标题 | 16px | **15px** |
| 附件/相关文件列表项 | 16px | **13px** |
| 相关台账信息标题/链接 | 16px | **15px / 13px** |

### 2. 移动端间距与布局
- 字段卡片：新增 `mobile-field-card` 类，统一 12px 垂直间距（对齐新版 `space-y-3`）
- 分组标题间距：上下对称 12px（之前 16px / 4px 不对称）
- 分组标题底部：保留 `::after` 2px solid #9ca3af 分隔线
- 只读签字字段：`.instance-sign-content` margin 10px → 2px（解决空签字框过高）
- 提交人/日期：水平 padding 16px → 8px，对齐表单卡片左右边距

### 3. 签字字段视觉修正（PC + 移动端统一）
- 签字字段（`config.type === 'approval_comments'`）虽然 `permission=editable`，但用户不能直接编辑（由审批栏自动带入）
- 在源头判断（`flow.js`），签字字段不显示黄色可编辑背景，视觉上按只读处理
- PC 端 `getTdField` 与移动端 `getFormMobileView` 统一规则

## 改动统计

| 文件 | 净增行 |
|---|---|
| `flow.js` | +18 / -7 |
| `AmisInstanceDetail.less` | +89 / -33 |

## 风险评估

| 风险点 | 影响范围 | 等级 |
|---|---|---|
| 移动端字体/间距 | 全部 scoped 在 `.instance-form-view-mobile` 或 `@media (max-width: 768px)` 内 | **极低** — PC 端不受影响 |
| 签字字段去黄色背景（PC + 移动端） | `getTdField` / `getFormMobileView` 中 `config.type === 'approval_comments'` 的字段 | **低** — 视觉更合理（用户本就不能直接编辑），但 PC 端审批表单的签字字段会从黄色背景变成白色，建议做一次 PC 端回归 |
| 只读签字字段紧凑 padding | 仅 `.mobile-readonly-field .instance-sign-content` | **极低** |

## 合并提示

本分支 merge-base 较早，主分支（6.10）后续在 `attachment.js`、`AmisSteedosField.tsx`、`RelatedInstances.tsx` 以及 `flow.js` 的只读箱公式部分有新提交。**合并前建议先 rebase 主分支以避免冲突**：

```bash
git fetch origin && git rebase origin/6.10
```