### PR TITLE
fix(ApprovalTreeMenu): bypass tooltip on touch devices to fix mobile residual overlay (#738)

### DIFF
--- a/packages/@steedos-widgets/amis-object/src/components/ApprovalTreeMenu.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/ApprovalTreeMenu.tsx
@@ -272,9 +272,26 @@ interface TreeNode {
 }
 
 /**
+ * 是否为支持真实 hover 的设备（鼠标 / 触控板）。
+ *
+ * 仅在桌面级精确指针 + 真 hover 设备上才启用 Tooltip。
+ * 触屏设备（手机 / 触屏平板）会合成 mouseenter 但不会触发 mouseleave，
+ * 导致受控 Tooltip 残留在屏幕上（见 issue #738）。直接 bypass 即可避免。
+ *
+ * SSR 安全：服务端无 window 时退化为 false（不渲染 Tooltip，无副作用）。
+ */
+const SUPPORTS_HOVER =
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+
+/**
  * EllipsisTooltip — 仅在文字实际被截断（scrollWidth > clientWidth）时才显示 antd Tooltip。
  * 通过 labelRef 检测内层 label 是否溢出，通过 open prop 控制 Tooltip 显示。
  * Tooltip 包裹整个容器，这样 hover 在 padding 区域和角标上也能触发。
+ *
+ * 触屏设备（!SUPPORTS_HOVER）直接返回 children，不挂 Tooltip / mouse 事件，
+ * 避免 tap 后 mouseleave 缺失导致的浮层残留问题（issue #738）。
  */
 const EllipsisTooltip: React.FC<{
   title: React.ReactNode;
@@ -293,6 +310,11 @@ const EllipsisTooltip: React.FC<{
   const handleMouseLeave = React.useCallback(() => {
     setVisible(false);
   }, []);
+
+  // 触屏设备没有可靠的 mouseleave，直接 bypass 整个 Tooltip 逻辑。
+  if (!SUPPORTS_HOVER) {
+    return children;
+  }
 
   return (
     <Tooltip


### PR DESCRIPTION
## 问题
issue #738：手机端真机上，从待办页左侧审批菜单选择"流程分类"或"流程名称"后，列表能按条件正常过滤，但**被点中节点的 tooltip 长驻显示在列表上方**，盖住内容、影响阅读，必须切走再回来才会消失。

## 根因
`EllipsisTooltip`（[ApprovalTreeMenu.tsx:279-311](https://github.com/steedos/steedos-widgets/blob/6.10/packages/@steedos-widgets/amis-object/src/components/ApprovalTreeMenu.tsx#L279-L311)）使用受控 `Tooltip open={visible}`，仅靠 `onMouseEnter`/`onMouseLeave` 切换 `visible`：
- 触屏设备点击节点会合成 `mouseenter` → `setVisible(true)`；
- 但**手指抬起后不会触发 `mouseleave`**，`visible` 永远停留在 `true`；
- 导致 tooltip 残留。

已通过 Chrome DevTools 在 iPhone 模拟模式下复现：hover 截断节点（如"数智技术中心设备维修审批单"）后 tooltip 显示，且无法靠后续点击关闭。

## 修复
在不支持真实 hover 的设备上直接 bypass `Tooltip`，只返回 `children`：

```ts
const SUPPORTS_HOVER =
  typeof window !== 'undefined' &&
  typeof window.matchMedia === 'function' &&
  window.matchMedia('(hover: hover) and (pointer: fine)').matches;
```

设备能力在会话期间不会变化，故用模块级常量。SSR 安全由 `typeof window !== 'undefined'` 守住。

## 设计依据（业界规范）
- Tooltip 是"鼠标 hover 后查看完整文本"的桌面专属交互，触屏设备没有 hover 概念；
- MUI / Ant Design Mobile / CSS `@media (hover: hover) and (pointer: fine)` 都遵循此原则；
- 对比方案：
  - 加 `onTouchEnd` 关闭 → tap 仍会闪一下且分类切换/滚动场景仍可能残留；
  - 长按显示+点击关闭 → 与 antd Tooltip 默认行为冲突，移动端不主流。

## 影响范围
- ✅ 手机端：截断节点不再显示 tooltip，无残留浮层；
- ✅ 桌面端：保持原有 hover-on-overflow 行为不变；
- ✅ 触屏平板：按业界规范同手机端，不显示 tooltip；
- 唯一改动：`EllipsisTooltip` 函数（22 行新增，无删除）。

## 验证
- [x] 桌面 Chrome 模拟手机模式：`window.matchMedia('(hover: hover) and (pointer: fine)').matches === false` 实测确认；
- [x] 桌面端 hover 触发条件不变（`SUPPORTS_HOVER === true`，原逻辑全部保留）；
- [x] `yarn build:rollup` 通过（仅 pre-existing 警告）；
- [ ] 手机真机回归 issue #738 复现路径。

Closes #738

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>