### PR TITLE
fix: 三栏/手机端列表卡片字段行顶部对齐

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/lib/converter/amis/fields/table.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/converter/amis/fields/table.js
@@ -838,7 +838,7 @@ function getMobileLines(tpls){
     let isNewLine = false;
     let isLeft = true;
     let lineChildrenClassName = "";
-    let lineClassName = "flex items-center justify-between mb-1";
+    let lineClassName = "flex items-start justify-between mb-1";
     tpls.forEach(function(item){
         if(isNewLine && lines.length < maxLineCount){
             lines.push({


### PR DESCRIPTION
## 问题

三栏模式和手机端列表中，每条记录渲染为多字段卡片时，当左侧字段文字较长换行后，同一行的右侧字段会被居中对齐到左侧多行块的"中间高度"，视觉上错位。

## 根因

`getMobileLines()` 函数（table.js line 841）中卡片行使用了 `items-center`（垂直居中），导致换行场景下右侧字段被推到左侧块的中线位置。

## 修复

将 `items-center` 改为 `items-start`（顶部对齐）。

```diff
- let lineClassName = \"flex items-center justify-between mb-1\";
+ let lineClassName = \"flex items-start justify-between mb-1\";
```

**兼容性**：未换行场景下 `items-start` 与 `items-center` 视觉等价（单行高度一致），对现有表现无回归影响。

**改动范围**：三栏模式（split）与手机端（SMALL）共用 `getMobileLines()` 渲染路径，一处修复同时解决两端问题。

Fixes steedos/steedos-plugins#758