### PR TITLE
fix: 列表卡片上下边距对称（去除最后一行的 mb-1）

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/lib/converter/amis/fields/table.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/converter/amis/fields/table.js
@@ -902,7 +902,11 @@ function getMobileLines(tpls){
             "className": lineClassName
         });
     }
-    
+
+    if(lines.length){
+        lines[lines.length - 1].className = lineClassName.replace(" mb-1", "");
+    }
+
     return lines;
 }
 


### PR DESCRIPTION
## 问题

在 #635 修复字段顶部对齐后，发现列表卡片每条记录的**上下边距不对称**：

- 顶部空白 = `td.padTop(6.4)` + `wrapper.padTop(4)` = **10.4px**
- 底部空白 = `wrapper.padBottom(4)` + 最后一行 `mb-1`(4) + `td.padBottom(6.4)` = **14.4px**

差异 4px 来自最后一行残留的 `mb-1`（典型的 last-child margin 问题）。

## 修复

在 `getMobileLines()` 返回前，去掉最后一行的 `mb-1`，保留中间各行的间距。

```diff
+ if(lines.length){
+     lines[lines.length - 1].className = lineClassName.replace(" mb-1", "");
+ }
  return lines;
```

## 验证

DOM 实测前后对比：

| 指标 | 修复前 | 修复后 |
|---|---|---|
| topGap | 10px | 10px |
| bottomGap | 14px | **10px** ✅ |
| 最后一行 marginBottom | 4px | 0px |

PC 三栏与手机端共享同一渲染路径，一处修复双端生效。

Refs steedos/steedos-plugins#758