### PR TITLE
fix(workflow): force readonly fields in v1 print page (#748)

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -20,6 +20,29 @@ import { getSafeCode, getTableFieldMap, mapFormula } from './formula-utils';
 // 当前表单是否为纯只读箱（监控箱、已完成等），用于控制只读字段是否需要响应式公式计算
 let _isReadonlyBox = false;
 
+// v1 老版表单打印态字段递归只读化
+// 背景：v1 路径下，字段是否可编辑由 field.permission === "editable" 决定，
+// `print` 参数本身不参与该判断，导致从待办/草稿进入打印页时表单仍可编辑（issue #748）。
+// 同时子表(table)的新增/编辑/删除按钮由 field.permission 控制（见 getTdInputTpl 中 case "table"），
+// section 内嵌字段也需要同步处理。
+// 注意：本函数仅用于 v1 标准打印路径，v2 通过 formMode='print' 自行处理只读，
+// 自定义 print_template 走 liquid/JSON 渲染，均不需要调用本函数。
+const normalizeLegacyPrintFields = (fields) => {
+  if (!Array.isArray(fields)) {
+    return;
+  }
+  fields.forEach((field) => {
+    if (!field || typeof field !== 'object') {
+      return;
+    }
+    field.permission = 'readonly';
+    // section 嵌套字段 / table 子字段
+    if (Array.isArray(field.fields)) {
+      normalizeLegacyPrintFields(field.fields);
+    }
+  });
+};
+
 const getSelectOptions = (field) => {
   const options = [];
   if(!field.options){
@@ -1623,6 +1646,12 @@ export const getFlowFormSchema = async (instance, box, print) => {
           instanceFormSchema = workflowFormV2Schema
           console.log('instanceFormSchema v2', instanceFormSchema, instance.approveValues, instance);
       }else{
+        // v1 标准打印路径：print=true 时把所有字段（含 section/table 子字段）改为只读，
+        // 否则会渲染成可编辑控件（issue #748）
+        if (print) {
+          _isReadonlyBox = true;
+          normalizeLegacyPrintFields(instance.fields);
+        }
         if (isMobile) {
           formContentSchema = await getFormMobileView(instance, tableFieldMap);
         }


### PR DESCRIPTION
Fixes steedos/steedos-plugins#748

## 问题
从待办/草稿进入审批单"打印"页面时，老版本（v1）表单的字段仍渲染为可编辑控件（textbox / number / textarea / combobox），子表还会显示 `+ 新增` 按钮。新版本（v2）表现正常。

## 根因
`getFlowFormSchema` 的 v1 路径下，字段是否可编辑由 `field.permission === "editable"` 决定，`print` 参数从未参与该判断；从 inbox/draft 进入时字段权限仍为 editable，于是打印页也渲染成可编辑表单。
- v2 路径已通过 `formMode='print'` 由 workflow-form-v2 组件统一处理只读。
- 自定义 `print_template` 走 liquid/JSON 渲染，不依赖字段权限。

## 修复
新增 `normalizeLegacyPrintFields` helper，仅在 v1 标准打印路径进入 `getFormTableView / getFormWizardView / getFormMobileView` 前调用，递归将 `field.permission` 置为 `readonly`，覆盖 section 嵌套字段。子表（table）的 `addable/editable/removable` 已在 `getTdInputTpl` 中由 `field.permission` 驱动，因此一并失效。

## 验证（已使用 playwright MCP 实测）

| 场景 | recordId | 修复前可编辑控件数 | 修复后 |
|---|---|---|---|
| v1 老表单打印页 | `69fecc04cfcc3e259c102650` | 19（含 12 input + 7 combobox）+ 1 个 `+ 新增` | **0 / 0** ✓ |
| v2 新表单打印页 | `69feeb42cfcc3e259c102659` | 0 | **0** ✓（不回归） |

## 影响范围
- ✅ v1 标准打印：所有字段、section 嵌套、子表新增/编辑/删除入口均只读
- ✅ v2 打印：不受影响
- ✅ 自定义 `print_template`：不受影响
- ✅ 非打印场景：`if (print)` 严格守卫，编辑能力不变
- ✅ 单元测试 `formula-utils.test.js` 全绿（68/68）
- ✅ `yarn build-rollup` 通过