### PR TITLE
fix(workflow): add workflow-print-draft body class on draft print preview

### DIFF
--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.tsx
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.tsx
@@ -25,6 +25,16 @@ export const AmisInstanceDetail = async (props) => {
 
     // console.log('AmisInstanceDetail===>', props);
     const instanceInfo = await getInstanceInfo({instanceId: instanceId, box: boxName, print});
+    // Hide approval-history block on draft print preview — relies on CSS rule
+    // shipped by steedos-plugins page_instance_print.page.amis.json.
+    // See steedos/steedos-plugins#271
+    if (print && typeof document !== 'undefined') {
+      if (instanceInfo && instanceInfo.state === 'draft') {
+        document.body.classList.add('workflow-print-draft');
+      } else {
+        document.body.classList.remove('workflow-print-draft');
+      }
+    }
     // console.log('AmisInstanceDetail===instanceInfo>', instanceInfo);
     const schema = await getFlowFormSchema(instanceInfo, boxName, print) as any;
     const applicant = await getApplicant(instanceInfo.applicant);


### PR DESCRIPTION
## Problem

On the print preview page of a workflow instance whose state is `draft`, the approval-history section was still rendered (empty) at the bottom, and the "签核历程 / 精简" checkboxes in the top toolbar still showed even though they had no meaningful effect.

Cross-repo issue: steedos/steedos-plugins#271

## Solution

`AmisInstanceDetail` already fetches the instance via `getInstanceInfo` (which returns `state`). After that call, when running in print mode, toggle `workflow-print-draft` on `document.body`:

- add the class when `state === 'draft'`
- remove it otherwise (handles route changes / non-draft prints)

The CSS that actually hides the approval-history block and the related toolbar checkboxes lives in the plugins repo (`page_instance_print.page.amis.json`); see companion PR steedos/steedos-plugins#761.

No new requests, no API changes — purely reuses data already in the page.

## Verification

Local steedos-plugins build + Playwright:

- Draft instance (`697df044c1c06f83ff46af4e`): body gets `workflow-print-draft`; approval history hidden; toolbar only shows 「附件」.
- Completed instance (`69b81c87eba9593553c98681`): no class added; approval history visible; toolbar shows all three checkboxes.

Fixes steedos/steedos-plugins#271