### PR TITLE
fix: 手机端签批历程改为紧凑表格布局对齐旧系统 steedos/steedos-plugins#759

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/workflow/history.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/history.js
@@ -9,68 +9,87 @@
 import _, { each } from 'lodash';
 import i18next from "i18next";
 
+// 手机端紧凑表格：步骤名独占一整行 + 审批明细三列（审批人 / 时间 / 结果）
+// + 可选意见行，对齐旧系统“签核历程”信息密度。
 const getMobileInstanceApprovalHistory = async () => {
     return {
         "type": "liquid",
         "className": "m-b-none bg-white",
         "template": `
-            <div class="instance-approve-history w-full bg-white border-t border-gray-100 mt-2">
-                <div class="text-base font-bold py-3 px-4 text-gray-800 border-b border-gray-100">签批历程</div>
-                <div class="flex flex-col w-full text-sm text-left pb-4">
+            <div class="instance-approve-history w-full bg-white mt-2">
+                <div class="text-base font-bold pb-2 text-gray-800">签批历程</div>
+                <table class="w-full table-fixed border-collapse text-xs text-left text-gray-900">
+                    <colgroup>
+                        <col style="width:28%" />
+                        <col style="width:44%" />
+                        <col style="width:28%" />
+                    </colgroup>
+                    <tbody>
                     {% for trace in historyApproves %}
                         {% assign children_count = trace.children | size %}
                         {% if children_count > 0 %}
-                            
-                            <!-- Step Name as Section Title -->
-                            <div class="px-4 pt-4 pb-2 text-xs font-bold text-gray-500 uppercase tracking-wider">
-                                {{ trace.name }}
-                            </div>
-
+                            <!-- 步骤名行：独占一整行 -->
+                            <tr class="step-type-{{trace.step_type}} bg-gray-100">
+                                <td class="px-1.5 py-1 font-medium text-gray-700 border-b border-gray-200" colspan="3">
+                                    {{ trace.name }}
+                                </td>
+                            </tr>
                             {% for item in trace.children %}
-                                <div class="px-4 py-3 mx-4 bg-gray-50 rounded mb-2 border border-gray-100 shadow-sm">
-                                    <!-- Opinion -->
-                                    {% if item.opinion and item.opinion != '' %}
-                                    <div class="mb-3 pb-2 border-b border-gray-200 text-sm text-gray-700 leading-relaxed">
-                                        {{ item.opinion }}
-                                    </div>
-                                    {% endif %}
-                                    <div class="flex justify-between items-start">
-                                        <!-- User Name & Status -->
-                                        <div class="flex flex-col w-full">
-                                            <div class="flex items-center justify-between gap-2 w-full">
-                                                <span class="font-bold text-gray-900 text-[15px]">{{ item.user_name }}</span>
-                                                <!-- Status Badge (text only) -->
-                                                {% if item.judge and item.judge != '' %}
-                                                <span class="text-xs px-2 py-0.5 rounded-full font-medium whitespace-nowrap flex items-center
-                                                    {% if item.auto_submitted %}bg-orange-100 text-orange-600 border border-orange-200
-                                                    {% elsif item.judgeValue == 'approved' %}bg-green-100 text-green-700 border border-green-200
-                                                    {% elsif item.judgeValue == 'rejected' %}bg-red-100 text-red-700 border border-red-200
-                                                    {% elsif item.finish_date == '${i18next.t('frontend_workflow_approval_history_read')}' %}bg-blue-50 text-blue-600 border border-blue-200
-                                                    {% else %}bg-gray-100 text-gray-600 border border-gray-200{% endif %}">
-                                                    {% if item.auto_submitted %}<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3 h-3 mr-1"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>{% endif %}{{ item.judge }}
+                                {% capture row_class_name %}step-type-{{trace.step_type}} {{item.type}}-step-type-{{trace.step_type}} {{item.type}}-step-id-{{trace.step_id}} {{item.type}}-judge-{{item.judgeValue}}{% if item.type == 'approve' %} approve-type-{{item.approve_type}}{% endif %}{% endcapture %}
+                                <!-- 审批明细行：审批人 / 时间 / 结果 -->
+                                <tr class="bg-white {{ row_class_name }}">
+                                    <td class="px-1.5 py-1 align-middle border-b border-gray-100 truncate">{{ item.user_name }}</td>
+                                    <td class="px-1.5 py-1 align-middle border-b border-gray-100 whitespace-nowrap text-gray-600">
+                                        {% if item.finish_date == '${i18next.t('frontend_workflow_approval_history_read')}' %}
+                                            <span class="text-sky-500">{{ item.finish_date }}</span>
+                                        {% elsif item.finish_date == '${i18next.t('frontend_workflow_approval_history_unprocessed')}' %}
+                                            <span class="text-red-500">{{ item.finish_date }}</span>
+                                        {% else %}
+                                            {{ item.finish_date | slice: 5, 11 }}
+                                        {% endif %}
+                                    </td>
+                                    <td class="px-1.5 py-1 align-middle border-b border-gray-100 text-center">
+                                        {% if item.judge and item.judge != '' %}
+                                            {% if item.auto_submitted %}
+                                                <span class="inline-flex items-center font-bold whitespace-nowrap" style="color: orange;">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3.5 h-3.5 mr-0.5">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                    </svg>
+                                                    {{ item.judge }}
                                                 </span>
-                                                {% endif %}
-                                            </div>
-                                            <!-- Date -->
-                                            <div class="text-xs text-gray-400 mt-1.5 flex items-center">
-                                                {% if item.finish_date == '${i18next.t('frontend_workflow_approval_history_read')}' or item.finish_date == '${i18next.t('frontend_workflow_approval_history_unprocessed')}' %}
-                                                    <!-- Special status text replacing date -->
-                                                    <span class="{% if item.finish_date == '${i18next.t('frontend_workflow_approval_history_read')}' %}text-blue-500 bg-blue-50 px-1.5 py-0.5 rounded{% elsif item.finish_date == '${i18next.t('frontend_workflow_approval_history_unprocessed')}' %}text-red-500 bg-red-50 px-1.5 py-0.5 rounded{% endif %}">
-                                                        {{ item.finish_date }}
-                                                    </span>
-                                                {% else %}
-                                                    <!-- Regular Date -->
-                                                    <svg class="w-3 h-3 mr-1 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                                                    {{ item.finish_date }}
-                                                {% endif %}
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
+                                            {% elsif item.judgeValue == 'approved' %}
+                                                <span class="inline-flex items-center text-green-600 font-bold whitespace-nowrap">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-3.5 h-3.5 mr-0.5">
+                                                        <path fill-rule="evenodd" d="M19.916 4.626a.75.75 0 01.208 1.04l-9 13.5a.75.75 0 01-1.154.114l-6-6a.75.75 0 011.06-1.06l5.353 5.353 8.493-12.739a.75.75 0 011.04-.208z" clip-rule="evenodd" />
+                                                    </svg>
+                                                    {{ item.judge }}
+                                                </span>
+                                            {% elsif item.judgeValue == 'rejected' %}
+                                                <span class="inline-flex items-center text-red-600 font-bold whitespace-nowrap">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3.5 h-3.5 mr-0.5">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                                                    </svg>
+                                                    {{ item.judge }}
+                                                </span>
+                                            {% else %}
+                                                {{ item.judge }}
+                                            {% endif %}
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                {% if item.opinion and item.opinion != '' %}
+                                    <!-- 意见行：跨 3 列，最多 2 行省略 -->
+                                    <tr class="bg-white {{ row_class_name }}">
+                                        <td class="px-1.5 py-1 border-b border-gray-100 text-gray-700" colspan="3">
+                                            <div style="display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;word-break:break-all;">{{ item.opinion }}</div>
+                                        </td>
+                                    </tr>
+                                {% endif %}
                             {% endfor %}
                         {% endif %}
                     {% endfor %}
-                </div>
+                    </tbody>
+                </table>
             </div>
         `
     }

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -1099,44 +1099,14 @@
 
         /* 签批历程区域优化：与表单左右对齐、字体统一 */
         .instance-approve-history {
-            /* 与表单 px-2 对齐，覆盖模板中的 border-t */
-            padding-left: 0 !important;
-            padding-right: 0 !important;
+            /* 与附件/表单区域对齐，左右各留 8px */
+            padding-left: 8px !important;
+            padding-right: 8px !important;
             margin-top: 16px !important;
 
-            /* 标题 "签批历程"：与表单字段标题对齐 */
+            /* 标题 "签批历程"：字号统一 */
             > div:first-child {
-                padding-left: 8px !important;
-                padding-right: 8px !important;
                 font-size: 16px !important;
-            }
-
-            /* 内容容器 */
-            > .flex.flex-col {
-                font-size: 14px !important;
-
-                /* 步骤名称（如"开始"、"车间主管领导(会签)"） */
-                > div[class*="px-4"][class*="text-xs"] {
-                    padding-left: 8px !important;
-                    padding-right: 8px !important;
-                    font-size: 14px !important;
-                }
-
-                /* 每条审批卡片 */
-                > div[class*="px-4"][class*="mx-4"] {
-                    margin-left: 8px !important;
-                    margin-right: 8px !important;
-                    
-                    /* 审批人名字 */
-                    .text-\[15px\] {
-                        font-size: 15px !important;
-                    }
-                    
-                    /* 意见文字 */
-                    .text-sm {
-                        font-size: 14px !important;
-                    }
-                }
             }
         }
     }


### PR DESCRIPTION
## 关联 Issue

steedos/steedos-plugins#759 「手机端签批历史改造」第一阶段。

## 背景

旧系统手机端「签核历程」是一个高密度的小字号表格，能一屏看完整流程；新系统手机端目前用的是大卡片流（每条审批一张卡片，含头像、状态徽章、日期图标），信息密度远低于旧系统，长流程下用户需要频繁滚动。

本 PR 把新系统的手机端审批历程改成与旧系统对齐的 3 列紧凑表格，PC 端 0 改动。

## 改动清单

### `packages/@steedos-widgets/amis-lib/src/workflow/history.js`

重写 `getMobileInstanceApprovalHistory()`：

- 由卡片流改为 `<table class="w-full table-fixed text-xs">`，列宽 `28% / 44% / 28%`（审批人 / 时间 / 结果）
- 步骤名独占一整行（`colspan=3`，`bg-gray-100`），与下面的审批明细行视觉分组
- 时间字段：
  - 真实日期 `YYYY-MM-DD HH:mm` → liquid `slice: 5, 11` 取 `MM-DD HH:mm` 短格式
  - i18n 状态 `已读` → `text-sky-500`，`未处理` → `text-red-500`，不切割
- 结果列保留判定图标：`auto_submitted`（橙色时钟）/ `approved`（绿勾）/ `rejected`（红叉），缩小到 `w-3.5 h-3.5`
- 意见行可选（仅 `item.opinion` 非空时渲染），`colspan=3`，使用行内 `-webkit-line-clamp:2` 限制最多两行（Tailwind purge 不会生成 `line-clamp-*` 工具类，故走 style）
- 保留所有语义类钩子：`step-type-{{trace.step_type}}`、`{{item.type}}-step-type-*`、`{{item.type}}-step-id-*`、`{{item.type}}-judge-{{item.judgeValue}}`、`approve-type-{{item.approve_type}}` —— 租户自定义样式继续命中

### `packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less`

- 清理针对旧卡片 DOM 的死规则：`> .flex.flex-col`、`[class*="px-4"][class*="text-xs"]`、`[class*="px-4"][class*="mx-4"]` 等选择器在新表格 DOM 上不命中，删除
- `.steedos-mobile-view .instance-approve-history` 的 `padding-left/right` 由 `0 !important` 改为 `8px !important`，让「签批历程」标题与表格内容跟附件区、表单区左右对齐（实测均为容器内 20px 起）

## 影响范围

| 区域 | 是否受影响 |
|------|------------|
| 审批流程实例详情页 - 手机端（`window.innerWidth < 768`） | ✅ 是 |
| 审批流程实例详情页 - PC 端 | ❌ 否（`getInstanceApprovalHistory(box, isMobile)` 在 `isMobile=false` 分支模板与样式完全未触碰，桌面 4 列 rowspan 布局保持原状） |
| 其他对象详情页 / 列表 / 表单 / 传阅弹窗 | ❌ 否 |
| 后端、API、数据结构 | ❌ 否 |

## 风险评估：低

1. CSS 改动局限在 `.steedos-mobile-view .instance-approve-history`，桌面端 `.steedos-mobile-view` 不挂载
2. 被删除的 less 规则原本针对旧卡片 DOM，新模板下本就不命中，删除是清理而非破坏
3. 数据契约未变，仍消费 `historyApproves[].children[]` 现有字段
4. amis liquid `slice` 过滤器与 i18next `t()` 表达式插值已验证

## 验证

- 移动端 390×844 viewport 实测：
  - 8 条审批可一屏看完，密度对齐旧系统
  - 无横向滚动（`scrollWidth === innerWidth`）
  - 签名图正常渲染
  - `已读` / `未处理` / `MM-DD HH:mm` 三类时间显示正确
  - 长意见 2 行省略
  - 「签批历程」标题、表格内容、附件区标题左边均为 20px，右边均为 470px——左右对齐
- PC 端代码路径未变更，桌面 4 列 rowspan 模板源码完整保留（history.js L110–232）

## 第二阶段（不在本 PR）

Issue #759 还包含第二阶段「点击行弹出审批明细抽屉」，且需要同时在 PC 和手机端生效。该改动会影响桌面端交互，将单独提交 PR 评审。
