### PR TITLE
fix(workflow): hide approval history on draft print via amis expression

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -1754,7 +1754,7 @@ export const getFlowFormSchema = async (instance, box, print) => {
   return {
     type: "page",
     name: "instancePage",
-    className: "steedos-amis-instance-view sm:rounded " + "steedos-instance-style-" + formStyle + (isMobile ? " steedos-mobile-view" : ""),
+    className: "steedos-amis-instance-view sm:rounded " + "steedos-instance-style-" + formStyle + (isMobile ? " steedos-mobile-view" : "") + (print && instance.state === 'draft' ? " steedos-instance-print-draft" : ""),
     bodyClassName: "overflow-y-auto h-full steedos-amis-instance-view-body",
     headerClassName: "p-0",
     "title": print ? null : {

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.tsx
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.tsx
@@ -43,6 +43,9 @@ export const AmisInstanceDetail = async (props) => {
         record: instanceInfo,
         applicant: applicant
       }
+    if (print) {
+      schema.className = `${schema.className || ''} \${record.state === 'draft' ? 'workflow-print-draft' : ''}`.trim();
+    }
     // console.log(`AmisInstanceDetail schema`, props, schema)
     return schema;
 }

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.tsx
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.tsx
@@ -43,9 +43,6 @@ export const AmisInstanceDetail = async (props) => {
         record: instanceInfo,
         applicant: applicant
       }
-    if (print) {
-      schema.className = `${schema.className || ''} \${record.state === 'draft' ? 'workflow-print-draft' : ''}`.trim();
-    }
     // console.log(`AmisInstanceDetail schema`, props, schema)
     return schema;
 }


### PR DESCRIPTION
For steedos/steedos-plugins#271.

When rendering the workflow instance detail in **print mode**, attach an amis expression `className` to the schema root so that draft instances carry a `workflow-print-draft` marker class:

```js
if (print) {
  schema.className = `${schema.className || ''} \${record.state === 'draft' ? 'workflow-print-draft' : ''}`.trim();
}
```

Pairs with the plugins-side CSS rule
`.workflow-print-draft .instance-approve-history { display: none }` (steedos/steedos-plugins#761).

## Why amis expression instead of DOM body class
Previous draft of this fix (the now-closed PR #638) toggled `document.body.classList`. Reviewer (issue author) asked whether the plugins schema could do it alone via the `record.state` already exposed in the amis scope. Investigation showed:

- `record` is injected at this widget's `schema.data` (line 43) — i.e. **inside** this widget
- The plugins outer `service`/page scope does NOT see it (amis data scope is parent→child only, no upward bubbling)
- So the marker MUST be set inside this widget — but it can still be amis-native, with zero DOM side effects.

## Test plan
- ✅ Draft instance print preview: `.instance-approve-history` hidden, ancestor `.antd-Page` carries `workflow-print-draft`
- ✅ Completed instance print preview: history visible, no marker class
- ✅ No `document.body` mutation, no cleanup needed