### PR TITLE
fix(workflow): reset applicant tr padding/gap in print media

### DIFF
--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -1171,3 +1171,16 @@
         }
     }
 }
+
+/* Chrome 真实打印窗口将 A4 渲染为 ~602px 宽，会命中 768px 媒体查询的移动端紧凑布局，
+   导致 .instance-applicant-view 的 tr 8px padding/gap 让提交人离左/顶、提交日期离右
+   产生过大边距。打印场景下重置为 0，与桌面端打印预览页面表现保持一致。
+   注意：本规则必须放置在 .steedos-amis-instance-view 选择器外、文件末尾，
+   避免与 @media (max-width: 768px) 嵌套被 Less 编译为非法的
+   "(max-width: 768px) and print" 媒体查询。 */
+@media print {
+    .steedos-amis-instance-view .instance-applicant-view tr {
+        padding: 0 !important;
+        gap: 0 !important;
+    }
+}


### PR DESCRIPTION
## 问题
老版本（v1）审批单打印预览页面，在页面内看时提交人/提交日期布局正常，但点击左上角"打印"按钮弹出 Chrome 真打印预览窗口时：

- 提交人离左边距和顶部边距过大
- 提交日期离右边距和顶部边距过大（待审批等含日期列的单子）

参考重现：
- 草稿 v1：`/app/approve_workflow/page/page_instance_print?embed=1&recordId=69fecc04cfcc3e259c102650`
- 待审批 v1：`/app/approve_workflow/page/page_instance_print?embed=1&recordId=69fee116cfcc3e259c102653`

## 根因
Chrome 真打印预览将 A4 内容区渲染为约 602px 宽，触发了 `AmisInstanceDetail.less` 中 `@media (max-width: 768px)` 移动端断点。该断点对 `.instance-applicant-view tr` 设置了：

```less
padding: 8px;
gap: 8px;
display: flex;
```

导致提交人行在打印窗口中相对表单边界出现 8px 的上/左/右额外偏移。

## 修复
在 `AmisInstanceDetail.less` 末尾追加一段**顶层** `@media print` 规则，将打印场景下的 padding/gap 重置为 0：

```less
@media print {
  .steedos-amis-instance-view .instance-applicant-view tr {
    padding: 0 !important;
    gap: 0 !important;
  }
}
```

> 注意：不能将 `@media print` 嵌套在 `@media (max-width: 768px)` 内部，Less 会编译成无效的 `@media (max-width: 768px) and print`（media type 必须在前），浏览器会静默忽略。

## 验证
- 1280px 桌面屏幕：表现不变（移动端规则本身就不生效）
- Print emulation @ 602px：
  - 草稿（仅提交人一列）：td.left = 15 ✅（原 23）
  - 待审批（提交人+提交日期两列）：firstTd.left = 15，lastTd.right = 587 ✅
- PDF 渲染：提交人贴左、提交日期贴右，顶部不再有 8px 额外间距

## 影响范围
仅打印媒体 (`@media print`) 下生效，对屏幕端布局零影响，对新版本审批单（不使用 `.instance-applicant-view`）也无影响。

Refs: #748

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>