### PR TITLE
fix(workflow): reset print-media padding/gap for applicant & history

### DIFF
--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -1171,3 +1171,44 @@
         }
     }
 }
+
+// Chrome print preview renders A4 content at ~602px, which triggers the
+// mobile media query (max-width: 768px) and applies mobile-only styles
+// that visually mismatch the on-screen (desktop) print preview:
+//   - .instance-approve-history: padding-left/right 8px (narrows table),
+//     margin-top 16px (extra gap above history).
+//   - .instance-applicant-view: margin-top 8px (extra gap above row).
+//   - .instance-applicant-view tr: padding 8px + gap 8px (inset cells,
+//     extra top/bottom spacing).
+//   - .instance-applicant-view td (and inner .antd-TplField): font-size 13px
+//     instead of the desktop 14px (text looks visibly smaller in print).
+// Reset all of these in print so the printed output matches the on-page
+// preview rendered at desktop width.
+// Note: this @media print block MUST be at the top level (not nested inside
+// another @media query), otherwise Less compiles it to an invalid combined
+// query like "(max-width: 768px) and print" which browsers silently ignore.
+@media print {
+    .steedos-amis-instance-view {
+        .instance-approve-history {
+            padding-left: 0 !important;
+            padding-right: 0 !important;
+            margin-top: 0 !important;
+        }
+
+        .instance-applicant-view {
+            margin-top: 0 !important;
+
+            tr {
+                padding: 0 !important;
+                gap: 0 !important;
+            }
+
+            td,
+            td > .antd-TplField,
+            td .antd-TplField:first-child,
+            td .antd-TplField:last-child {
+                font-size: 14px !important;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 问题
老版本（v1）审批单打印预览页面，在 Chrome **真打印预览窗口**中存在两类边距异常（页面内预览正常）：

1. **签批历程表格变窄**：底部签批历程 table 比上方表单窄 16px（两侧各 8px）
2. **提交人/提交日期边距过大**：提交人离左/上、提交日期离右/上都有 8px 额外偏移

重现：
- 待审批 v1：`/app/approve_workflow/page/page_instance_print?embed=1&recordId=69fee116cfcc3e259c102653`
- 草稿 v1：`/app/approve_workflow/page/page_instance_print?embed=1&recordId=69fecc04cfcc3e259c102650`

## 根因
Chrome 真打印预览将 A4 内容区渲染为约 **602px** 宽，触发了 `AmisInstanceDetail.less` 中 `@media (max-width: 768px)` 移动端断点：

- `.instance-approve-history { padding-left: 8px !important; padding-right: 8px !important; }` → 内部历程表格变窄 16px
- `.instance-applicant-view tr { padding: 8px; gap: 8px; display: flex }` → 提交人/提交日期偏离表单边界

## 修复
在 `AmisInstanceDetail.less` 末尾追加**单个顶层** `@media print` 块，同时重置两处：

```less
@media print {
    .steedos-amis-instance-view {
        .instance-approve-history {
            padding-left: 0 !important;
            padding-right: 0 !important;
        }
        .instance-applicant-view tr {
            padding: 0 !important;
            gap: 0 !important;
        }
    }
}
```

> ⚠️ Less 嵌套陷阱：`@media print` 必须放在顶层，不能嵌套在 `@media (max-width: 768px)` 内，否则 Less 会编译成无效的 `(max-width: 768px) and print`（media type 必须在前），浏览器会静默忽略。

> 本 PR 同时包含了 #642 中提交人/提交日期 `tr padding/gap` 的修复（合并为同一个 print 块），#642 可关闭。

## 验证（Print emulation @ 602px viewport）

| 元素 | left | right | width |
|---|---|---|---|
| form | 15 | 587 | 572 |
| history 容器 | 15 | 587 | 572 |
| history table | **15** | **587** | **572** ✅ |
| applicant tr | 15 | 587 | 572 |
| applicant 提交人 td | **15** ✅ | 301 | 286 |
| applicant 提交日期 td | 301 | **587** ✅ | 286 |

全部贴齐表单边界。屏幕端 1280px 无回归（移动端断点本就不生效，print 规则也仅在 `@media print` 下生效）。

Refs: #748

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>