### PR TITLE
fix(workflow): omit empty <pre> description in v1 table-view label to remove extra gray underline

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -927,7 +927,7 @@ const getTdTitle = (field) => {
     body: [
       {
         type: "tpl",
-        tpl: `<div class='${field.type == "section" ? "font-bold" : ""}'>${field.name || field.code} <span class="antd-Form-star">*</span><pre class='font-normal'>${field.description || ''}</pre></div>`,
+        tpl: `<div class='${field.type == "section" ? "font-bold" : ""}'>${field.name || field.code} <span class="antd-Form-star">*</span>${field.description ? `<pre class='font-normal'>${field.description}</pre>` : ''}</div>`,
         className: field.is_required ? 'steedos-field-required' : (requiredOn ? {'steedos-field-required' : `${requiredOn}`} : '')
       },
     ],


### PR DESCRIPTION
## 问题

v1 老审批单 table-view 模式下，签字（approval_comments）字段所在单元格在浏览器窗口较窄、label 自动换行成 2 行时，字段值底部会显示一条多余的灰色横线。

## 根因

`getTdTitle` 的 label 模板（`flow.js` L930）总是输出空的 `<pre class='font-normal'></pre>`（当 `field.description` 为空时）：

```html
<div>项目所在单位工程管理部门 *<pre class="font-normal"></pre></div>
```

而 SLDS（salesforce-lightning-design-system.min.css）有全局规则：

```css
pre { border: 1px solid rgb(153, 153, 153); break-inside: avoid; }
```

被 Tailwind 的 `* { border-width: 0; }` 重置后，`pre` selector specificity 更高，仍然胜出，结果空 `<pre>` 渲染成高度 2px、全宽的灰色横线条，盘踞在 label 单元格底部。

- label 单行时：横线紧贴 label 文字下方，不显眼。
- label 换行时：横线下移到接近 row 底部，看起来就像签字字段值多了一条灰色下划线。

签字字段值区一般是空白（无值），所以这条线尤其抢眼；其他字段（输入框、下拉等）有自身控件覆盖，看不出来。

## 修复

仅当 `field.description` 非空时才输出 `<pre>` 描述节点：

```diff
- <span class="antd-Form-star">*</span><pre class='font-normal'>${field.description || ''}</pre>
+ <span class="antd-Form-star">*</span>${field.description ? `<pre class='font-normal'>${field.description}</pre>` : ''}
```

## 影响范围

- 仅 v1 老版本 workflow `style: table` 表单（`getFormTableView` → `getTdTitle`）。
- 不影响 v2 表单、mobile 视图、wizard 视图。
- 影响所有 v1 表格审批单页面 + v1 打印预览页面（同一段代码）。
- 有 description 的字段渲染逻辑保持不变。
- 验证页面：`pre.font-normal` 元素从 10 个 → 0 个。

Refs: steedos/steedos-plugins#271