### PR TITLE
feat: 支持读取对象 tree_expand 属性配置树列表默认展开行为

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/lib/converter/amis/fields/table.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/converter/amis/fields/table.js
@@ -1237,8 +1237,9 @@ export async function getTableSchema(object, fields, options){
     const treeConfig = {};
 
     if(options.enable_tree){
+        const expandValue = ['first', 'all', 'none'].indexOf(options.tree_expand) >= 0 ? options.tree_expand : 'first';
         treeConfig.expandConfig = {
-            expand: 'first'
+            expand: expandValue
         }
     }
 

--- a/packages/@steedos-widgets/amis-lib/src/lib/converter/amis/index.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/converter/amis/index.js
@@ -259,7 +259,7 @@ export async function getObjectCRUD(objectSchema, fields, options){
       let tableOptions = Object.assign({
         idFieldName: objectSchema.idFieldName, labelFieldName: labelFieldName, 
         permissions:objectSchema.permissions,enable_inline_edit:objectSchema.enable_inline_edit,
-        crudId: listSchema.id || id, enable_tree: objectSchema.enable_tree
+        crudId: listSchema.id || id, enable_tree: objectSchema.enable_tree, tree_expand: objectSchema.tree_expand
       }, options);
       tableOptions.amisData = createObject(options.amisData || {}, {});
       const table = await getTableSchema(objectSchema, fields, tableOptions);


### PR DESCRIPTION
## 概述
配合 steedos-platform PR #8347（issue steedos/steedos-platform#8346），支持读取对象元数据中的 `tree_expand` 属性来控制树状结构列表的默认展开行为。

## 改动
- `amis-lib/converter/amis/index.js`：在 `getObjectCRUD` 中将 `objectSchema.tree_expand` 透传给 table options
- `amis-lib/converter/amis/fields/table.js`：在 `treeConfig.expandConfig` 中读取 `options.tree_expand`
  - 仅接受 `first` / `all` / `none` 三种合法值
  - 其它值或未配置时降级为 `first`，保持向后兼容
  - 仅在 `enable_tree` 开启时生效

## 关联
- platform 端字段定义与 i18n：steedos/steedos-platform#8347
- Issue：steedos/steedos-platform#8346

## 验证
配合 platform PR 在浏览器中测试 B1-B11 全部通过：
- `first`：仅展开第一个根节点
- `all`：展开所有节点
- `none`：全部收起
- 旧对象未设置 tree_expand 时表现等同 `first`
