### PR TITLE
fix: 子表打印线条失真改用纯静态 HTML 表格渲染 (steedos/steedos-plugins#744)

### DIFF
--- a/.github/instructions/print-input-table.instructions.md
+++ b/.github/instructions/print-input-table.instructions.md
@@ -183,7 +183,7 @@ grep -rn "getPrintInputTableSchema\|_printTableFormatCell\|_printTableEvalFieldT
 |---|---|---|
 | **超宽子表 horizontal scroll** | 25 列超宽子表会把外层审批单一路撑宽 → 最外层页面级横向滚动条 | `.steedos-print-input-table-host` 加 `contain: inline-size; max-width: 100%` 切断"子树 max-content → 父 td 列宽"反向传递；`.steedos-print-input-table-wrap` 加 `overflow-x: scroll` 由 wrap 自身出横向滚动条 |
 | **打印态文字按字符竖排** | 之前给打印态加 `@media print { contain:none; min-width:0 }` 让 chrome 按 A4 压缩 → 25 列被等比挤到 30px/列 → 表头竖排 | 删除全部 `@media print` overrides，打印态与屏幕态完全统一：`contain:inline-size + min-width:max-content`；超 A4 由 chrome 自然截断 |
-| **真打印预览看不到右侧截断指示** | 子表超 A4 时打印预览只看到左侧 ~10 列，无任何提示右侧还有 15 列被截断 | wrap 用 `overflow-x: scroll`（非 auto）+ 自定义 `::-webkit-scrollbar` 样式 → chrome 打印预览也会渲染滚动条 track 作为视觉指示 |
+| **真打印预览看不到右侧截断指示** | 子表超 A4 时打印预览只看到左侧 ~10 列，无任何提示右侧还有 15 列被截断 | `.steedos-print-input-table-wrap` 仅在 `@media print` 加 `overflow-x: scroll` + 自定义 `::-webkit-scrollbar` 样式 → chrome 打印预览也会渲染滚动条 track 作为视觉指示；屏幕态保持 `overflow-x: auto` 不动，沿用系统原生滚动条（macOS overlay）与主分支体验一致 |
 | **A4 物理极限** | 超长字段 / 超多列总宽 > A4 → 内容溢出右侧被截断 | web 打印硬性物理极限，无法绕过。用户解法：系统打印对话框切换"横向 / A3 / 缩放比例"，或在屏幕态把 wrap 滚到右侧再点打印（chrome 按当前 scroll 位置截取） |
 | **预览页面视觉差异** | 子表是静态 HTML，无 amis 排序 / popover / 操作列等交互 | 设计取舍：打印场景本不需要 |
 
@@ -191,8 +191,8 @@ grep -rn "getPrintInputTableSchema\|_printTableFormatCell\|_printTableEvalFieldT
 
 #### 决策 D1：打印态与屏幕态视觉**完全一致**（当前实现）
 
-**现状**：删除全部 `@media print` overrides，打印态与屏幕态用同一套规则：
-- `wrap`: `overflow-x: scroll`
+**现状**：删除全部 `@media print` overrides，打印态与屏幕态用同一套规则（除滚动条样式外）：
+- `wrap`: 屏幕态 `overflow-x: auto`（系统原生滚动条）；打印态 `overflow-x: scroll` + 自定义 `::-webkit-scrollbar`（保证 chrome 打印预览渲染 track 作为截断指示）
 - `host`: `contain: inline-size; max-width: 100%`
 - `table`: `min-width: max-content`
 

--- a/.github/instructions/print-input-table.instructions.md
+++ b/.github/instructions/print-input-table.instructions.md
@@ -45,7 +45,20 @@ issue [steedos/steedos-plugins#744](https://github.com/steedos/steedos-plugins/i
 
 如果未来 amis 升级导致 renderer 行为变化，**必须**回归本指南 §3 的字段类型覆盖矩阵。
 
-## 3. 字段类型覆盖矩阵
+## 3. 为什么不用"点打印时 copy amis DOM"方案
+
+历史上讨论过另一个方案 B：预览页面保留 amis 原生子表，点击打印按钮时把 amis 渲染出的子表 DOM clone 到打印视图。**已放弃**，原因：
+
+| 维度 | 方案 A（当前）：预览态直接静态化 | 方案 B：点打印时 copy DOM |
+|---|---|---|
+| 解决线条失真 | ✅ 根治（绕开 amis/antd 渲染管线） | ❌ **不能解决** — 失真根因就在 amis input-table → antd Table 渲染产物（virtual list、sticky 列、内部 scroll 容器分页错乱），不管在哪个时机 copy 这个 DOM，chrome 打印引擎都还是会失真 |
+| 字段类型覆盖 | ⚠️ 需要 hand-port 每种类型 | ✅ 天然 100% |
+| 预览所见即所得 | ❌ 预览页面是静态表，与非打印 view 有视觉差 | ✅ 完全一致 |
+| 维护成本 | 中 | 低 |
+
+**结论**：方案 A 是被迫的最小可行解 — 不绕开 amis/antd 渲染管线就解决不了线条失真。
+
+## 4. 字段类型覆盖矩阵
 
 ### 已覆盖（commit `d239709f8` 起）
 
@@ -70,7 +83,7 @@ issue [steedos/steedos-plugins#744](https://github.com/steedos/steedos-plugins/i
 | html / markdown | `static-html` / `static-markdown` | 渲染为 DOM | 低 |
 | color | `static-color` | 渲染色块 | 低 |
 
-## 4. tpl 字符串安全约束（务必遵守）
+## 5. tpl 字符串安全约束（务必遵守）
 
 打印 tpl 是 lodash template + amis tpl 双引擎环境，有几个**致命陷阱**：
 
@@ -115,7 +128,7 @@ lodashTemplate(f.tpl, {
 - `variable: 'data'` 避免 `with` 性能问题
 - 自定义 `interpolate` 只匹配 `<%= %>` 不匹配 `${ }`（防止与 amis tpl 冲突）
 
-## 5. 验证流程
+## 6. 验证流程
 
 修改 `input_table.js` 或 `AmisInputTable.less` 后**必须**：
 
@@ -151,7 +164,7 @@ grep -rn "getPrintInputTableSchema\|_printTableFormatCell\|_printTableEvalFieldT
   packages/@steedos-widgets/amis-object/src
 ```
 
-## 6. 已知坑位（commit 历史教训）
+## 7. 已知坑位（commit 历史教训）
 
 - `78660e12d` — 修复 NaN 注入（`+ // 注释 + 'string'`）
 - `33bcbf7a4` — 移除按 value 正则判定数字的逻辑（误把电话号码格式化为千分位）
@@ -159,3 +172,37 @@ grep -rn "getPrintInputTableSchema\|_printTableFormatCell\|_printTableEvalFieldT
 - `d239709f8` — 收敛为 `type === 'input-number'` 判定 + 移除自加的 `__nowrap`（对齐非打印态行为）
 
 新改动若偏离上述任一结论，**必须**在 commit message 里说明理由。
+
+## 8. 已知 / 潜在"兜不住"的地方
+
+方案 A 绕开了 amis input-table，但代价是预览页面失去了 antd Table 的一些原生能力。改打印渲染前务必评估以下风险点：
+
+### 8.1 已知 / 已修
+
+| 类别 | 现象 | 处理 |
+|---|---|---|
+| **超宽子表 horizontal scroll** | 22 列超宽子表会把外层审批单一路撑宽 → 最外层页面级横向滚动条 | `.steedos-print-input-table-wrap` 在 `@media screen` 加 `overflow-x: auto`；`@media print` 改 `visible` 让 chrome 自然处理 A4 物理极限 |
+| **A4 物理极限** | 超长字段 / 超多列总宽 > A4 → 字号压缩或溢出 | 方案 A / B 都无解，需在内容侧解决（合并列、换行、缩字、横向 A4） |
+| **预览页面视觉差异** | 子表是静态 HTML，无 amis 排序 / popover / 操作列等交互 | 设计取舍：打印场景本不需要 |
+
+### 8.2 潜在风险（未实测，新增字段类型前务必验证）
+
+| 类别 | 风险描述 | 验证方法 |
+|---|---|---|
+| **行级 `visible_on` / `hidden_on` 表达式** | 静态表编译期没求值 → 该隐藏的行/列可能仍显示 | 找一个用了 `visible_on` 的子表对比非打印态 |
+| **自动列** | `_id` / checkbox / 操作列 / drag 列由 amis 运行时注入；`getPrintInputTableSchema` 只取 `props.fields`，列数可能不一致 | 对比 `<th>` 数量与非打印态 |
+| **行样式 `rowClassName` / `rowExpression`** | amis 行样式表达式静态表没实现 | 找配置了 rowClassName 的子表对比 |
+| **`enable_tree` 树形子表** | 父子关系、展开/折叠静态表完全没实现 | 树形子表打印是否需求？需求确认后再补 |
+| **`enable_drag` 拖动排序** | 静态表无 drag handle 列 | 同上，确认是否打印场景需要 |
+| **服务端 `_display` 字段** | 部分字段（lookup / formula / summary）依赖 `row._display[name]` | `_printTableFormatCell` 已优先取 `_display`，但未全字段验证 |
+
+### 8.3 验收清单（新改动后必跑）
+
+除 §6 的 T0–T6 PDF 矩阵外，还需在浏览器**预览态**确认：
+
+1. ✅ 子表过宽时，**子表自身**出水平滚动条；外层审批单不撑宽（对齐非打印态）
+2. ⏳ `visible_on` / `hidden_on` 行列正确隐藏
+3. ⏳ 自动列（checkbox / 操作列）数量与非打印态一致
+4. ⏳ `rowClassName` 行样式生效
+5. ⏳ 树形子表父子关系（若适用）
+

--- a/.github/instructions/print-input-table.instructions.md
+++ b/.github/instructions/print-input-table.instructions.md
@@ -181,11 +181,58 @@ grep -rn "getPrintInputTableSchema\|_printTableFormatCell\|_printTableEvalFieldT
 
 | 类别 | 现象 | 处理 |
 |---|---|---|
-| **超宽子表 horizontal scroll** | 22 列超宽子表会把外层审批单一路撑宽 → 最外层页面级横向滚动条 | `.steedos-print-input-table-wrap` 在 `@media screen` 加 `overflow-x: auto`；`@media print` 改 `visible` 让 chrome 自然处理 A4 物理极限 |
-| **A4 物理极限** | 超长字段 / 超多列总宽 > A4 → 字号压缩或溢出 | 方案 A / B 都无解，需在内容侧解决（合并列、换行、缩字、横向 A4） |
+| **超宽子表 horizontal scroll** | 25 列超宽子表会把外层审批单一路撑宽 → 最外层页面级横向滚动条 | `.steedos-print-input-table-host` 加 `contain: inline-size; max-width: 100%` 切断"子树 max-content → 父 td 列宽"反向传递；`.steedos-print-input-table-wrap` 加 `overflow-x: scroll` 由 wrap 自身出横向滚动条 |
+| **打印态文字按字符竖排** | 之前给打印态加 `@media print { contain:none; min-width:0 }` 让 chrome 按 A4 压缩 → 25 列被等比挤到 30px/列 → 表头竖排 | 删除全部 `@media print` overrides，打印态与屏幕态完全统一：`contain:inline-size + min-width:max-content`；超 A4 由 chrome 自然截断 |
+| **真打印预览看不到右侧截断指示** | 子表超 A4 时打印预览只看到左侧 ~10 列，无任何提示右侧还有 15 列被截断 | wrap 用 `overflow-x: scroll`（非 auto）+ 自定义 `::-webkit-scrollbar` 样式 → chrome 打印预览也会渲染滚动条 track 作为视觉指示 |
+| **A4 物理极限** | 超长字段 / 超多列总宽 > A4 → 内容溢出右侧被截断 | web 打印硬性物理极限，无法绕过。用户解法：系统打印对话框切换"横向 / A3 / 缩放比例"，或在屏幕态把 wrap 滚到右侧再点打印（chrome 按当前 scroll 位置截取） |
 | **预览页面视觉差异** | 子表是静态 HTML，无 amis 排序 / popover / 操作列等交互 | 设计取舍：打印场景本不需要 |
 
-### 8.2 潜在风险（未实测，新增字段类型前务必验证）
+### 8.2 设计决策记录
+
+#### 决策 D1：打印态与屏幕态视觉**完全一致**（当前实现）
+
+**现状**：删除全部 `@media print` overrides，打印态与屏幕态用同一套规则：
+- `wrap`: `overflow-x: scroll`
+- `host`: `contain: inline-size; max-width: 100%`
+- `table`: `min-width: max-content`
+
+**效果**：
+- 列宽按内容 max-content 自然分配（如 25 列 ~77px/列），文字单行清晰
+- 超 A4 部分被 chrome 物理截断到纸张右侧
+- 真打印预览同时显示横向滚动条 track 作为"右侧还有内容"的视觉指示
+
+**舍弃的对照方案 D2：跟进主分支让打印态压缩列宽塞下全部列**
+
+主分支（旧 antd Table 渲染）打印态强制 `.instance-form-view { table-layout: fixed; width: 100% }` + 子表 `width: 100%`，让所有列等比挤进 A4 配合 `white-space: normal` 允许表头换行。**已舍弃**，原因：
+
+1. 25 列 / ~750px = 30px/列时表头按字符竖排（实测 commit `bff02ad64` 的截图证据），用户看不清
+2. 数字短串如 "23232" 也会被错切，与 PR #650 主线想消除的"打印失真"目标冲突
+3. 屏幕预览（假打印）与真打印效果完全不一致，违反"所见即所得"原则
+4. chrome 系统打印对话框自带"横向 / A3 / 缩放比例"三个原生选项，是更合理的"塞下更多列"解法
+
+**如果未来需要切换到 D2**，技术实现（约 5 行 CSS）：
+
+```less
+// 给 .steedos-print-input-table-host 加：
+@media print {
+  contain: none;
+  max-width: none;
+}
+// 给 .steedos-print-input-table 加：
+@media print {
+  min-width: 0;
+  table-layout: fixed;
+}
+.steedos-print-input-table thead th {
+  @media print {
+    word-break: break-all;  // 允许按字符断行塞下
+  }
+}
+```
+
+⚠️ 切换前必须重新验证 T0-T6 矩阵，预期数字短串错切问题会回归（这是 D1 vs D2 的根本权衡）。
+
+### 8.3 潜在风险（未实测，新增字段类型前务必验证）
 
 | 类别 | 风险描述 | 验证方法 |
 |---|---|---|
@@ -196,13 +243,14 @@ grep -rn "getPrintInputTableSchema\|_printTableFormatCell\|_printTableEvalFieldT
 | **`enable_drag` 拖动排序** | 静态表无 drag handle 列 | 同上，确认是否打印场景需要 |
 | **服务端 `_display` 字段** | 部分字段（lookup / formula / summary）依赖 `row._display[name]` | `_printTableFormatCell` 已优先取 `_display`，但未全字段验证 |
 
-### 8.3 验收清单（新改动后必跑）
+### 8.4 验收清单（新改动后必跑）
 
-除 §6 的 T0–T6 PDF 矩阵外，还需在浏览器**预览态**确认：
+除 §6 的 T0–T6 PDF 矩阵外，还需在浏览器**预览态 + 真打印预览**确认：
 
 1. ✅ 子表过宽时，**子表自身**出水平滚动条；外层审批单不撑宽（对齐非打印态）
-2. ⏳ `visible_on` / `hidden_on` 行列正确隐藏
-3. ⏳ 自动列（checkbox / 操作列）数量与非打印态一致
-4. ⏳ `rowClassName` 行样式生效
-5. ⏳ 树形子表父子关系（若适用）
+2. ✅ 真打印预览（Cmd+P）也能看到子表底部的横向滚动条 track（D1 决策的视觉指示）
+3. ⏳ `visible_on` / `hidden_on` 行列正确隐藏
+4. ⏳ 自动列（checkbox / 操作列）数量与非打印态一致
+5. ⏳ `rowClassName` 行样式生效
+6. ⏳ 树形子表父子关系（若适用）
 

--- a/.github/instructions/print-input-table.instructions.md
+++ b/.github/instructions/print-input-table.instructions.md
@@ -60,7 +60,7 @@ issue [steedos/steedos-plugins#744](https://github.com/steedos/steedos-plugins/i
 
 ## 4. 字段类型覆盖矩阵
 
-### 已覆盖（commit `d239709f8` 起）
+### 已覆盖（commit `d239709f8` 起 + D 阶段补全）
 
 | Steedos 字段类型 | amis 中间 type | 打印态处理 | 实现位置 |
 |---|---|---|---|
@@ -69,19 +69,22 @@ issue [steedos/steedos-plugins#744](https://github.com/steedos/steedos-plugins/i
 | select / boolean / lookup（schema 含 `tpl` 的） | 带 `tpl` 的 `static` | `_printTableEvalFieldTpl` 预编译求值 | `lodashTemplate(f.tpl, {variable:'data', interpolate:/<%=([\s\S]+?)%>/g})` 缓存到 `window.__steedosPrintFieldTpls` |
 | boolean（无 tpl 兜底） | — | "是" / "否" | `_printTableFormatCell` |
 | 数组 / 对象 | — | `join(', ')` 或 `name/label/value` 取值 | `_printTableFormatCell` |
+| **date / datetime / time** | `static-date` / `static-datetime` | 上层 `Tpl.getDateTpl` / `getDateTimeTpl` 直接返回 `${_display.<name>}`；此处走 `_display` 兜底即对齐非打印态 | `_printTableFormatCell` `_display` 分支 |
+| **formula / summary** | 继承 `data_type` 的 static 渲染 | 上层 `Tpl.getUiFieldTpl` 返回 `${_display.<name>}`；走 `_display` 兜底 | `_printTableFormatCell` `_display` 分支 |
+| **master_detail（单值）** | `picker` (static) / 同 lookup | 上层 `Tpl.getNameTpl/getRelatedFieldTpl` 渲染 `${_display.<name>.label}`；走 `_display` 兜底 | `_printTableFormatCell` `_display` 分支 |
+| **multi-select / multi-lookup / multi-master_detail** | `static-mapping` / picker multiple | `_display[name]` 通常为 `[{label,value}]`：按 `label/name/value` 取出后 `join(', ')`（D 阶段修复了之前把数组当对象返回空的回归） | `_printTableFormatCell` `_display` 分支新增的 `Array.isArray(d)` 路径 |
+| **image / avatar / multi-image** | `static-image(s)` | `_printTableFormatImage` 输出 `<img class="steedos-print-input-table__img"/>`，src 优先 `_display[name].url`，回退 `row[name].url`，再回退字符串原值；多图按数组逐个渲染 | 单元格 `<%= %>` 不转义 + `.steedos-print-input-table__img` CSS 限制最大尺寸 60×120 |
+| **file / multi-file** | `control` + each | `_printTableFormatFile` 输出 `<a href=url target=_blank>name</a>`；多文件以空格分隔；打印态去掉链接样式只保留文字 | 单元格 `<%= %>` 不转义 + `.steedos-print-input-table__file` CSS |
 
-### 未覆盖（follow-up，需按 §1 原则补全）
+### 未覆盖（低优 follow-up，需按 §1 原则补全）
 
 | Steedos 字段类型 | amis 中间 type | 应有行为（参考 amis renderer） | 优先级 |
 |---|---|---|---|
-| date / datetime / time | `static-date` / `static-datetime` | 按字段 `format` 格式化（`Date.tsx`） | 高 |
-| multi-select（multiple:true） | `static-mapping` | 映射为 label 数组 | 高 |
-| image | `static-image(s)` | 渲染缩略图（`Image.tsx`） | 中 |
-| file | `static` + file ref | 文件名 + 下载链接（`File.tsx`） | 中 |
-| formula / summary | 依赖服务端 `_display` 回填 | 取 `row._display[name]` 兜底已实现，需验证 | 中 |
-| master_detail | `static` lookup | 关联记录 name | 中 |
-| html / markdown | `static-html` / `static-markdown` | 渲染为 DOM | 低 |
+| html | `input-rich-text`(readonly) / `html` | 渲染富文本 DOM | 低 |
+| markdown | `static-markdown` | 渲染 markdown DOM | 低 |
 | color | `static-color` | 渲染色块 | 低 |
+
+> 当前 html / markdown / color 字段会落入字符串兜底分支，按原值转义输出；不会报错但视觉与 amis 非打印态不一致。补全时建议在 `getPrintInputTableSchema` 的 cellTemplates 构建处用 `useRawHtml = true` 分支，并新增 `_printTableFormatHtml` / `_printTableFormatColor` helper，参考已有的 image/file 分发模式。
 
 ## 5. tpl 字符串安全约束（务必遵守）
 

--- a/.github/instructions/print-input-table.instructions.md
+++ b/.github/instructions/print-input-table.instructions.md
@@ -257,3 +257,110 @@ grep -rn "getPrintInputTableSchema\|_printTableFormatCell\|_printTableEvalFieldT
 5. ⏳ `rowClassName` 行样式生效
 6. ⏳ 树形子表父子关系（若适用）
 
+## 9. 代码架构与实现
+
+> **维护约束**：新增 / 删除 / 改名 `_printTable*` helper 或调整两阶段执行模型时，必须同步更新本节。本节是 PR review 时的"代码地图"。
+
+### 9.1 两阶段执行模型
+
+打印路径分两步、跨两个时间点执行，不分清这两层就**无法理解**为什么需要 `_printTplImports`、为什么 helper 要内嵌在 tpl 字符串里。
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 阶段 A：构建期（页面加载、amis schema 生成时，Node/浏览器主线程）│
+│   getPrintInputTableSchema(props)                               │
+│   ├─ 遍历 props.fields                                          │
+│   ├─ 为每列调用 cellTemplates 分发器决定 tpl 形态               │
+│   │    ├─ image/file → 走 <%= rawHTML %>（不转义）              │
+│   │    ├─ date       → 走 _printTableFormatDate(...)            │
+│   │    ├─ 字段自带 tpl → 预编译并存入 window.__steedosPrintFieldTpls │
+│   │    └─ 默认       → 走 _printTableFormatCell(...)            │
+│   └─ 返回 amis schema { type: 'tpl', tpl: '<table>...</table>' }│
+└─────────────────────────────────────────────────────────────────┘
+                              ↓ amis 把 schema 渲染为 DOM 时
+┌─────────────────────────────────────────────────────────────────┐
+│ 阶段 B：运行期（amis tpl 引擎 + lodash template 求值，浏览器）  │
+│   tpl 字符串内嵌的 `<% ... %>` JS 代码块在此真正执行：           │
+│   ├─ 调用内嵌的 _printTableFormatCell / _printTableFormatNumber │
+│   ├─ 调用 _printTableEvalFieldTpl（取 window.__steedosPrintFieldTpls）│
+│   └─ 输出最终 HTML                                              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**关键推论**：
+- helpers 必须以**字符串形式拼进 tpl**（不能 import），因为它们在阶段 B 才被求值，且求值环境是 lodash template 内部作用域。
+- 阶段 A 预编译的字段 `tpl`（如 `<%=data.qty?date(...) %>`）需要在阶段 B 调用 `date()` 等过滤器 → 必须显式注入 `imports`，对齐 `amis-core/utils/tpl-lodash.js`（见 §9.3）。
+
+### 9.2 Helper 分层调用图
+
+```
+单元格 tpl 字符串
+   │
+   ├─ image/avatar/multi-image 列 → _printTableFormatImage(row, field)
+   │      └─ _printTableEscapeHtml + <img class="steedos-print-input-table__img">
+   │
+   ├─ file/multi-file 列          → _printTableFormatFile(row, field)
+   │      ├─ _printTableNormalizeFiles（统一数组形态）
+   │      └─ _printTableEscapeHtml + <a class="steedos-print-input-table__file">
+   │
+   ├─ date/datetime 列            → _printTableFormatDate(val, field)
+   │      └─ 按 type=date 用 UTC，否则本地时区；用 moment 格式化
+   │
+   ├─ 字段自带 tpl 列              → _printTableEvalFieldTpl(row, fieldName, tableKey)
+   │      └─ 取 window.__steedosPrintFieldTpls[tableKey][fieldName]（构建期预编译）
+   │            └─ 求值时 lodash template 接收 _printTplImports（见 §9.3）
+   │
+   └─ 默认                         → _printTableFormatCell(row, field)
+          ├─ 优先 row._display[name]（服务端已格式化）
+          │    ├─ Array.isArray(d)  → 按 label/name/value join(', ')  ★ 必须先于 typeof object
+          │    ├─ typeof === 'object' → 取 label/name/value
+          │    └─ 其它原值
+          ├─ field.type === 'input-number' → _printTableFormatNumber（原始小数位千分位）
+          ├─ boolean → "是" / "否"
+          ├─ 数组 → join(', ')
+          ├─ 对象 → label/name/value
+          └─ 字符串兜底 + _printTableEscapeHtml
+```
+
+### 9.3 `_printTplImports` 与 amis-core/tpl-lodash 的对齐
+
+字段自带 tpl 形如 `<%=data.start_date ? date(new Date(data.start_date), 'YYYY-MM-DD') : '' %>`，里面的 `date / formatDate / number / formatNumber` 在非打印态由 amis 注入。打印态我们自己用 lodash template 编译，**必须显式注入**：
+
+```js
+const _printTplImports = {
+  date: (val, fmt)         => moment(val).format(fmt),
+  formatDate: (val, fmt)   => moment(val).format(fmt),
+  number: (val)            => Number(val),
+  formatNumber: (val, ...) => /* 千分位 */,
+};
+lodashTemplate(f.tpl, { variable: 'data', interpolate: /<%=([\s\S]+?)%>/g, imports: _printTplImports });
+```
+
+**对应上游**：`node_modules/amis-core/src/utils/tpl-lodash.ts` 的 `imports` 定义。amis 升级时若该文件新增过滤器（如 `truncate`、`json` 等），**必须同步**到这里，否则字段 tpl 里调用新过滤器会抛 `xxx is not defined` 并整列退化为空字符串。
+
+### 9.4 `window.__steedosPrintFieldTpls` 索引方案
+
+多张子表可能同时存在于一个打印页（如审批单含 2-3 个 input-table）。字段名可能撞车（两张子表都有 `amount`），且各自编译的 lodash template 函数不同。
+
+```js
+window.__steedosPrintFieldTpls = {
+  [tableKey1]: { fieldA: compiledFn, fieldB: compiledFn, ... },
+  [tableKey2]: { fieldA: compiledFn /* 不同的函数 */, ... },
+};
+```
+
+- `tableKey` = 构建期为每张子表生成的唯一 id（基于 `props.name` + 计数），写死进 tpl 字符串
+- 阶段 B 求值时 `_printTableEvalFieldTpl(row, fieldName, tableKey)` 用这个 key 精确定位
+- **不要去掉 tableKey 退化为单层 `{ fieldName: fn }`**：会导致后渲染的子表覆盖前者的预编译函数
+
+### 9.5 维护约束（PR review 必查）
+
+新增 / 删除字段类型分支时：
+
+1. 在 §4 矩阵增减一行
+2. 在 §9.2 分层调用图增减对应分支
+3. 若新增 helper，在 §9.2 列出它的输入 / 输出 / 上游 amis renderer 路径
+4. 若依赖 `_printTplImports` 新过滤器，更新 §9.3 + 同步注释指向 amis 上游
+5. 阶段 A 改动（schema 生成层）会影响所有子表 → 必须跑完 §6 T0–T6
+6. 阶段 B 改动（helper 内部逻辑）只影响特定字段类型 → 至少跑覆盖该类型的 T*
+

--- a/.github/instructions/print-input-table.instructions.md
+++ b/.github/instructions/print-input-table.instructions.md
@@ -1,0 +1,161 @@
+---
+applyTo: "**/input_table.js,**/AmisInputTable*"
+description: "Use when modifying the print-mode rendering of子表 (input-table) in print pages — getPrintInputTableSchema, _printTableFormatCell, AmisInputTable.less print styles. Covers rule-source-of-truth principle, tpl pipeline safety, and field-type coverage."
+---
+
+# 子表打印模式 (`getPrintInputTableSchema`) — 开发指南
+
+## 背景
+
+issue [steedos/steedos-plugins#744](https://github.com/steedos/steedos-plugins/issues/744) 修复"子表打印时边框线失真"。方案是为打印路径单独走一条**纯静态 HTML 表格 + lodash template** 的渲染（`getPrintInputTableSchema`），绕开 amis input-table / antd Table 的运行时渲染。
+
+入口：[`packages/@steedos-widgets/amis-lib/src/lib/input_table.js`](../../packages/@steedos-widgets/amis-lib/src/lib/input_table.js) → `getPrintInputTableSchema(props)`
+
+打印开关三条件任一：
+- `props.print === true`
+- `window.location.pathname` 匹配 `/page/page_instance_print`
+- `localStorage.STEEDOS_PRINT_INPUT_TABLE === '1'`
+
+## 核心原则
+
+### 1. 规则来源 — 严禁从 UI 反推
+
+子表单元格只读渲染的"规则"**不在本仓库**，分布在三层：
+
+1. **amis 上游 renderer**（最终行为）：`node_modules/amis/src/renderers/{Static,InputNumber,Date,Select,File,Image,…}.tsx` 的 `static: true` 分支。
+2. **AmisSteedosField 中间层**：[`packages/@steedos-widgets/amis-object/src/amis/AmisSteedosField.tsx`](../../packages/@steedos-widgets/amis-object/src/amis/AmisSteedosField.tsx)（`getAmisStaticFieldType()` 把 Steedos 字段类型派生为 amis 子 schema 的 type）。
+3. **Steedos 字段转 amis schema**：[`packages/@steedos-widgets/amis-lib/src/lib/converter/amis/fields/index.js`](../../packages/@steedos-widgets/amis-lib/src/lib/converter/amis/fields/index.js)（普通表单字段路径，**子表 cell 不走这里**）。
+
+**新增/修改字段类型的打印格式化规则时，必须按以下顺序确认**：
+
+1. **看源码先**：先在 `AmisSteedosField.tsx` 找到该 Steedos 字段类型派生出的 amis 子 schema（type / static / precision / format / pipeIn 等）。
+2. **看 amis renderer**：再在 `node_modules/amis/src/renderers/<对应 type>.tsx` 的 static 分支，看它实际生成什么 DOM / 文本。
+3. **翻译到打印 tpl**：在 `_printTableFormatCell` 或 `_printTableEvalFieldTpl` 里实现等价输出，**注释里必须指明源码路径 + 行号**。
+4. **UI 实测验证**：打开非打印态 `page_instance_view` 同一记录，对比单元格 textContent，必须 1:1 一致。
+
+> ⚠️ **UI 实测只是验证，不是规则来源。** 之前的 commit 历史里有过"按 UI 表现反推规则"的尝试（例如把数量列也加上千分位），最终都因偏离 amis renderer 真实行为被回退。
+
+### 2. 共用源码不可行的原因
+
+理论上最干净的做法是把 `AmisSteedosField` 的只读分支抽成纯函数，给打印路径直接调用。**目前不可行**：
+
+- `AmisSteedosField` 输出的是 amis 中间 schema，**最终格式化仍由 amis renderer 运行时**完成（如 `input-number static` 的千分位）。
+- 打印路径是 lodash template 编译期产物，**无法在 tpl 字符串内嵌 amis 运行时**。
+- 因此现实做法只能是 hand-port amis renderer 的 static 行为到打印 tpl，并在注释里指向源码。
+
+如果未来 amis 升级导致 renderer 行为变化，**必须**回归本指南 §3 的字段类型覆盖矩阵。
+
+## 3. 字段类型覆盖矩阵
+
+### 已覆盖（commit `d239709f8` 起）
+
+| Steedos 字段类型 | amis 中间 type | 打印态处理 | 实现位置 |
+|---|---|---|---|
+| text / textarea / autonumber / url / email / password | `static` | 原值 | `_printTableFormatCell` 默认分支 |
+| number / currency / percent | `input-number` (`static:true`) | `_printTableFormatNumber` 按原始小数位千分位 | `_printTableFormatCell` 数字分支 |
+| select / boolean / lookup（schema 含 `tpl` 的） | 带 `tpl` 的 `static` | `_printTableEvalFieldTpl` 预编译求值 | `lodashTemplate(f.tpl, {variable:'data', interpolate:/<%=([\s\S]+?)%>/g})` 缓存到 `window.__steedosPrintFieldTpls` |
+| boolean（无 tpl 兜底） | — | "是" / "否" | `_printTableFormatCell` |
+| 数组 / 对象 | — | `join(', ')` 或 `name/label/value` 取值 | `_printTableFormatCell` |
+
+### 未覆盖（follow-up，需按 §1 原则补全）
+
+| Steedos 字段类型 | amis 中间 type | 应有行为（参考 amis renderer） | 优先级 |
+|---|---|---|---|
+| date / datetime / time | `static-date` / `static-datetime` | 按字段 `format` 格式化（`Date.tsx`） | 高 |
+| multi-select（multiple:true） | `static-mapping` | 映射为 label 数组 | 高 |
+| image | `static-image(s)` | 渲染缩略图（`Image.tsx`） | 中 |
+| file | `static` + file ref | 文件名 + 下载链接（`File.tsx`） | 中 |
+| formula / summary | 依赖服务端 `_display` 回填 | 取 `row._display[name]` 兜底已实现，需验证 | 中 |
+| master_detail | `static` lookup | 关联记录 name | 中 |
+| html / markdown | `static-html` / `static-markdown` | 渲染为 DOM | 低 |
+| color | `static-color` | 渲染色块 | 低 |
+
+## 4. tpl 字符串安全约束（务必遵守）
+
+打印 tpl 是 lodash template + amis tpl 双引擎环境，有几个**致命陷阱**：
+
+### 4.1 严禁裸 `$`
+
+amis 内置 tpl 引擎（`tpl-builtin`）会优先匹配带 `$` 的模板，从而**抢占 lodash 引擎**，导致 `<% %>` 块完全被忽略，最终返回空。
+
+```js
+// ❌ 错误：裸 $ 会被 amis builtin 引擎抢占
+const tpl = '<td>$<%= row.amount %></td>';
+
+// ✅ 正确：用 HTML entity 或避免
+const tpl = '<td><%= row.amount %></td>';
+```
+
+### 4.2 严禁在 `+` 拼接的行尾写 `//` 注释
+
+```js
+// ❌ 错误：`+ //` 会让下一行的 `+'string'` 退化为一元 +，把字符串转成 NaN
+const tpl = ''
+  + '<% var x = 1; %>'  // 这里有注释
+  + '<%- x %>';
+
+// ✅ 正确：注释独占一行，放在拼接表达式上方
+const tpl = ''
+  // 计算 x
+  + '<% var x = 1; %>'
+  + '<%- x %>';
+```
+
+### 4.3 lodash template 选项约定
+
+`_printTableEvalFieldTpl` 编译字段 `tpl` 时统一使用：
+
+```js
+lodashTemplate(f.tpl, {
+  variable: 'data',
+  interpolate: /<%=([\s\S]+?)%>/g,
+});
+```
+
+- `variable: 'data'` 避免 `with` 性能问题
+- 自定义 `interpolate` 只匹配 `<%= %>` 不匹配 `${ }`（防止与 amis tpl 冲突）
+
+## 5. 验证流程
+
+修改 `input_table.js` 或 `AmisInputTable.less` 后**必须**：
+
+```bash
+# 1. 重建 amis-lib（dist 是被 unpkg 引用的产物）
+cd packages/@steedos-widgets/amis-lib && yarn build
+
+# 2. 重建 amis-object（依赖 amis-lib 的 dist）
+cd ../amis-object && yarn build
+
+# 3. 浏览器硬刷新（ignoreCache）打印页：
+#    http://127.0.0.1:5100/app/approve_workflow/page/page_instance_print?recordId=<ID>
+```
+
+### 回归矩阵
+
+| 代号 | recordId | 验收点 |
+|---|---|---|
+| T0 | `6a0426c5ddaead2b9baa6f6c` | 6 列 3 行基线不退化 |
+| T1 | `69c3e2b5d17fcb69e263b8f1` | 单行最简不退化 |
+| T2 | `69e97878674a33474159967a` | 多子表不退化 |
+| T3 | `69d8becdb7df097f875a4bec` | 长文本不竖排 |
+| T4 | `69dced421f5fd36df3a218cc` | 数字千分位 + 不强加小数位 |
+| T5 | `69dce2bd1f5fd36df3a218b9` | 超多列 28 不出现失真线 |
+| T6 | `69dce8af1f5fd36df3a218c3` | 超多列 + 多行不退化 |
+
+### grep 同步检查（改动后必跑）
+
+```bash
+# 确认改动没有破坏其它使用方
+grep -rn "getPrintInputTableSchema\|_printTableFormatCell\|_printTableEvalFieldTpl\|__steedosPrintFieldTpls" \
+  packages/@steedos-widgets/amis-lib/src \
+  packages/@steedos-widgets/amis-object/src
+```
+
+## 6. 已知坑位（commit 历史教训）
+
+- `78660e12d` — 修复 NaN 注入（`+ // 注释 + 'string'`）
+- `33bcbf7a4` — 移除按 value 正则判定数字的逻辑（误把电话号码格式化为千分位）
+- `afd4bc016` — 移除按 className 含 `steedos-field-number-readonly` 判定数字（数量列被错误加千分位）
+- `d239709f8` — 收敛为 `type === 'input-number'` 判定 + 移除自加的 `__nowrap`（对齐非打印态行为）
+
+新改动若偏离上述任一结论，**必须**在 commit message 里说明理由。

--- a/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
@@ -1579,17 +1579,17 @@ async function getButtonDelete(props) {
 
 // 子表打印渲染器开关（issue steedos/steedos-plugins#744 子表打印线条失真）
 // 命中条件（满足任一即可）：
-//   1. props.print === true（上层显式声明，预留链路）
-//   2. 当前 URL pathname 包含 /page/page_instance_print（审批打印页，稳定标识）
-//   3. localStorage.STEEDOS_PRINT_INPUT_TABLE = '1'（调试 / 灰度兜底，可移除）
+//   1. props.print === true —— 唯一正式数据流；由 page_instance_print.page.amis.json
+//      在 adaptor 里给 steedos-instance-detail 组件传 print:true，AmisInstanceDetail
+//      透传给 getFlowFormSchema，flow.js 的 case "table" 再写入子表 schema.print。
+//   2. localStorage.STEEDOS_PRINT_INPUT_TABLE = '1' —— 调试 / 灰度兜底，方便在
+//      普通审批查看页（非打印 URL）临时启用打印渲染器排查问题，不影响生产。
 // 命中后 getAmisInputTableSchema 会绕开 amis input-table / antd Table，
 // 改用纯静态 HTML 表格渲染，彻底规避超宽列布局导致的文字压扁失真问题。
 const isPrintInputTableEnabled = (props) => {
     try {
         if (props && props.print === true) return true;
         if (typeof window === 'undefined') return false;
-        const pathname = (window.location && window.location.pathname) || '';
-        if (/\/page\/page_instance_print(\/|$)/.test(pathname)) return true;
         if (window.localStorage && window.localStorage.STEEDOS_PRINT_INPUT_TABLE === '1') return true;
     } catch (e) {
         // 任意环境异常都视为未开启，回落到原 amis input-table 路径

--- a/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
@@ -1668,6 +1668,10 @@ const getPrintInputTableSchema = (props) => {
     const rowsExpr = JSON.stringify(props.name);
     const visibleFieldNamesJson = JSON.stringify(visibleFieldNames);
 
+    // 数值字段名集合（用于 tpl 内运行时判定是否需要千分位）
+    const numericFieldNames = fields.filter(isNumericField).map((f) => f.name);
+    const numericFieldNamesJson = JSON.stringify(numericFieldNames);
+
     const cellTemplates = fields
         .map((f) => {
             const nameJson = JSON.stringify(f.name);
@@ -1699,6 +1703,19 @@ const getPrintInputTableSchema = (props) => {
         // 所有说明请放在拼接表达式上方，不要写在 + 之间。
         + 'var _printTableRows = (data && data[' + rowsExpr + ']) || []; '
         + 'var _printTableVisibleFields = ' + visibleFieldNamesJson + '; '
+        + 'var _printTableNumericFields = ' + numericFieldNamesJson + '; '
+        + 'var _printTableIsNumericField = function(name){ '
+        +   'for (var i = 0; i < _printTableNumericFields.length; i++) { if (_printTableNumericFields[i] === name) return true; } '
+        +   'return false; '
+        + '}; '
+        + 'var _printTableFormatNumber = function(v){ '
+        +   'var n = typeof v === "number" ? v : Number(String(v).replace(/,/g, "")); '
+        +   'if (!isFinite(n)) return null; '
+        +   'var s = String(v).replace(/,/g, ""); '
+        +   'var dot = s.indexOf("."); '
+        +   'var frac = dot >= 0 ? s.length - dot - 1 : 0; '
+        +   'return n.toLocaleString("en-US", { minimumFractionDigits: frac, maximumFractionDigits: Math.max(frac, 0) }); '
+        + '}; '
         + 'var _printTableFormatCell = function(row, name){ '
         +   'if (!row) return ""; '
         +   'var d = row._display && row._display[name]; '
@@ -1709,6 +1726,10 @@ const getPrintInputTableSchema = (props) => {
         +   'var v = row[name]; '
         +   'if (v === null || v === undefined) return ""; '
         +   'if (typeof v === "boolean") return v ? "是" : "否"; '
+        +   'if (_printTableIsNumericField(name) && (typeof v === "number" || typeof v === "string")) { '
+        +     'var fn = _printTableFormatNumber(v); '
+        +     'if (fn !== null) return fn; '
+        +   '} '
         +   'if (Array.isArray(v)) { '
         +     'return v.map(function(item){ '
         +       'if (item && typeof item === "object") return item.name || item.label || item.value || JSON.stringify(item); '

--- a/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
@@ -7,7 +7,7 @@
 
 import { getFormBody } from './converter/amis/form';
 import { getComparableAmisVersion } from './converter/amis/util';
-import { clone, cloneDeep, debounce } from 'lodash';
+import { clone, cloneDeep, debounce, template as lodashTemplate } from 'lodash';
 import { uuidv4 } from '../utils/uuid';
 import i18next from "i18next";
 
@@ -1619,9 +1619,44 @@ const getPrintInputTableSchema = (props) => {
     const showIndex = props.showIndex !== false;
     const visibleFieldNames = fields.map((f) => f.name);
 
-    // 注意：进入打印链路时 props.fields[*].type 已被上层转成 amis 的 'static' / 'input-number' 等，
-    // 不再是 Steedos 原 'number'/'currency'/'date'。因此 nowrap class 与千分位等需要
-    // 在 tpl 运行时按 row[name] 实际值类型判断，不在 schema 生成期按字段 type 判断。
+    // 字段在进入打印链路时已被上层转换成 amis 形式：
+    // - readonly 文本类: { type: 'static', className: '...steedos-field-input-readonly' }
+    // - readonly 数字类: { type: 'static', className: '...steedos-field-number-readonly' }
+    //   或 { type: 'input-number', static: true, precision: ... }
+    // - readonly 选项类: { type: 'static', className: '...steedos-field-select-readonly', tpl: '<% ... %>' }
+    // 因此判定方式：
+    //   nowrap   ← className 含 'steedos-field-number-readonly' 或 type === 'input-number'
+    //   渲染值   ← 有 tpl 时用 lodash.template 求值（对齐非打印态 static-tpl 行为），否则取 _display[name] 或 row[name]
+    // 千分位不在此处加工，完全对齐非打印态（非打印态依赖服务端 _display，子表通常没有）。
+    const isNumericField = (f) => {
+        if (!f) return false;
+        if (f.type === 'input-number') return true;
+        const cls = typeof f.className === 'string' ? f.className : '';
+        return cls.indexOf('steedos-field-number-readonly') !== -1;
+    };
+
+    // 把 tpl 字段的 lodash 模板预编译并以 window 全局表暂存，运行时按 (tableKey|fieldName) 查找调用。
+    // 与 amis 内置 tpl-lodash 引擎一致：variable: 'data'，使得 tpl 内的 data["xxx"] 等价于 row["xxx"]。
+    const tableKey = (props.id || props.name || 'tbl') + '_' + uuidv4();
+    if (typeof window !== 'undefined') {
+        window.__steedosPrintFieldTpls = window.__steedosPrintFieldTpls || {};
+    }
+    fields.forEach((f) => {
+        if (f && typeof f.tpl === 'string' && f.tpl) {
+            try {
+                const fn = lodashTemplate(f.tpl, {
+                    variable: 'data',
+                    interpolate: /<%=([\s\S]+?)%>/g,
+                });
+                if (typeof window !== 'undefined') {
+                    window.__steedosPrintFieldTpls[tableKey + '|' + f.name] = fn;
+                }
+            } catch (e) {
+                // tpl 编译失败时回退到原值渲染，不阻塞表格输出
+            }
+        }
+    });
+
     const headerCells = [];
     if (showIndex) {
         headerCells.push('<th class="steedos-print-input-table__index">#</th>');
@@ -1636,11 +1671,18 @@ const getPrintInputTableSchema = (props) => {
     const cellTemplates = fields
         .map((f) => {
             const nameJson = JSON.stringify(f.name);
-            // class 用 <%= %>（不转义）避免双引号变 &quot;；cell 值用 <%- %> 防 XSS
-            return '<td<%= _printTableCellClass(row, ' + nameJson + ') %>><%- _printTableFormatCell(row, ' + nameJson + ') %></td>';
+            const cellClass = isNumericField(f)
+                ? ' class="steedos-print-input-table__nowrap"'
+                : '';
+            const valueExpr = (f && typeof f.tpl === 'string' && f.tpl)
+                ? ('_printTableEvalFieldTpl(row, ' + nameJson + ')')
+                : ('_printTableFormatCell(row, ' + nameJson + ')');
+            return '<td' + cellClass + '><%- ' + valueExpr + ' %></td>';
         })
         .join('');
     const indexCell = showIndex ? '<td class="steedos-print-input-table__index"><%- i + 1 %></td>' : '';
+
+    const tableKeyJson = JSON.stringify(tableKey);
 
     // 样式已迁移到 packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
     const tpl = '<div class="steedos-print-input-table-wrap" data-name="' + escapeHtmlForPrintTable(props.name) + '">'
@@ -1653,51 +1695,20 @@ const getPrintInputTableSchema = (props) => {
         // `+'string'` 退化为一元 `+`，把字符串转成 NaN 注入到 tpl 里。
         // 另外：tpl 字符串中 **绝对不要出现裸的 `$` 字符**（除非紧跟在 `\\` 后面）。
         // amis 内置 tpl 引擎(builtin)会优先匹配带 `$` 的模板，从而抢占 lodash 引擎，
-        // 导致 `<% %>` 块被完全忽略且最终返回空。这是数值正则 `/^...$/` 一开始失效的根因。
+        // 导致 `<% %>` 块被完全忽略且最终返回空。
         // 所有说明请放在拼接表达式上方，不要写在 + 之间。
         + 'var _printTableRows = (data && data[' + rowsExpr + ']) || []; '
         + 'var _printTableVisibleFields = ' + visibleFieldNamesJson + '; '
-        + 'var _printTableIsNumericValue = function(v){ '
-        +   'if (typeof v === "number") return isFinite(v); '
-        +   'if (typeof v !== "string" || v === "") return false; '
-        +   'var s = v.replace(/,/g, ""); '
-        +   'if (s.charAt(0) === "-") s = s.slice(1); '
-        +   'if (s === "" || s === ".") return false; '
-        +   'var dotSeen = false; '
-        +   'for (var i = 0; i < s.length; i++) { '
-        +     'var c = s.charCodeAt(i); '
-        +     'if (c === 46) { if (dotSeen) return false; dotSeen = true; continue; } '
-        +     'if (c < 48 || c > 57) return false; '
-        +   '} '
-        +   'return isFinite(Number(v.replace(/,/g, ""))); '
-        + '}; '
-        + 'var _printTableFormatNumber = function(v){ '
-        +   'var n = typeof v === "number" ? v : Number(String(v).replace(/,/g, "")); '
-        +   'if (!isFinite(n)) return String(v); '
-        +   'var s = String(v).replace(/,/g, ""); '
-        +   'var dot = s.indexOf("."); '
-        +   'var frac = dot >= 0 ? s.length - dot - 1 : 0; '
-        +   'return n.toLocaleString("en-US", { minimumFractionDigits: frac, maximumFractionDigits: Math.max(frac, 0) }); '
-        + '}; '
-        + 'var _printTableCellClass = function(row, name){ '
-        +   'if (!row) return ""; '
-        +   'var d = row._display && row._display[name]; '
-        +   'var v = (d !== null && d !== undefined && d !== "") ? d : row[name]; '
-        +   'if (_printTableIsNumericValue(v)) return " class=\\"steedos-print-input-table__nowrap\\""; '
-        +   'return ""; '
-        + '}; '
         + 'var _printTableFormatCell = function(row, name){ '
         +   'if (!row) return ""; '
         +   'var d = row._display && row._display[name]; '
         +   'if (d !== null && d !== undefined && d !== "") { '
         +     'if (typeof d === "object") return d.label || d.name || d.value || ""; '
-        +     'var ds = String(d); '
-        +     'return _printTableIsNumericValue(ds) ? _printTableFormatNumber(ds) : ds; '
+        +     'return String(d); '
         +   '} '
         +   'var v = row[name]; '
         +   'if (v === null || v === undefined) return ""; '
         +   'if (typeof v === "boolean") return v ? "是" : "否"; '
-        +   'if (_printTableIsNumericValue(v)) return _printTableFormatNumber(v); '
         +   'if (Array.isArray(v)) { '
         +     'return v.map(function(item){ '
         +       'if (item && typeof item === "object") return item.name || item.label || item.value || JSON.stringify(item); '
@@ -1706,6 +1717,14 @@ const getPrintInputTableSchema = (props) => {
         +   '} '
         +   'if (typeof v === "object") return v.name || v.label || v.value || JSON.stringify(v); '
         +   'return String(v); '
+        + '}; '
+        + 'var _printTableEvalFieldTpl = function(row, name){ '
+        +   'try { '
+        +     'var k = ' + tableKeyJson + ' + "|" + name; '
+        +     'var fn = (typeof window !== "undefined") && window.__steedosPrintFieldTpls && window.__steedosPrintFieldTpls[k]; '
+        +     'if (typeof fn === "function") { var s = fn(row || {}); return s == null ? "" : String(s); } '
+        +   '} catch(e) {} '
+        +   'return _printTableFormatCell(row, name); '
         + '}; '
         + '_printTableRows.forEach(function(row, i){ '
         + '%>'

--- a/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
@@ -1708,6 +1708,22 @@ const getPrintInputTableSchema = (props) => {
         +   'var frac = dot >= 0 ? s.length - dot - 1 : 0; '
         +   'return n.toLocaleString("en-US", { minimumFractionDigits: frac, maximumFractionDigits: Math.max(frac, 0) }); '
         + '}; '
+        // TODO(steedos/steedos-plugins#744 follow-up): _printTableFormatCell 只覆盖了以下字段类型：
+        //   ✅ text / textarea / autonumber / url / email / password —— 原值
+        //   ✅ number / currency / percent（amis 中间 type=input-number）—— 千分位
+        //   ✅ select / boolean / lookup（带 tpl 的）—— _printTableEvalFieldTpl 预编译求值
+        //   ✅ boolean（无 tpl 兜底）—— 是 / 否
+        //   ✅ 数组 / 对象 —— join(",") 或 name/label/value 取值
+        // 未覆盖（按 amis renderer static 模式行为补全，参考 node_modules/amis/src/renderers/）：
+        //   ❌ date / datetime / time —— 应按字段 format 格式化（Date.tsx）
+        //   ❌ multi-select（multiple:true）—— 应映射为 label 数组
+        //   ❌ image —— 应渲染缩略图（Image.tsx）
+        //   ❌ file —— 应渲染文件名 + 下载链接（File.tsx）
+        //   ❌ formula / summary —— 依赖服务端 _display 回填
+        //   ❌ master_detail —— 应取关联记录名称
+        //   ❌ html / markdown —— 应渲染为 DOM
+        //   ❌ color —— 应渲染色块
+        // 新增字段类型流程见 .github/instructions/print-input-table.instructions.md
         + 'var _printTableFormatCell = function(row, name){ '
         +   'if (!row) return ""; '
         +   'var d = row._display && row._display[name]; '

--- a/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
@@ -1636,12 +1636,59 @@ const getPrintInputTableSchema = (props) => {
     if (typeof window !== 'undefined') {
         window.__steedosPrintFieldTpls = window.__steedosPrintFieldTpls || {};
     }
+    // 与 amis-core/utils/tpl-lodash.js 对齐：上层 (workflow/flow.js / converter/amis/tpl.js)
+    // 生成的 tpl 经常调用 amis-formula 暴露的过滤器函数（最常见的是 date / number / formatDate）。
+    // 这些 tpl 在 amis 运行时由 tpl-lodash 引擎传 imports 后执行；本打印分支自行预编译时
+    // 必须把同样的辅助函数注入到 lodash template 的 imports 中，否则会抛
+    // "date is not defined" 之类的错误，进而被 _printTableEvalFieldTpl 捕获并落回原值，
+    // 表现为子表日期列渲染成 "2026-02-10T00:00:00.000Z" 这类 ISO 字符串。
+    const _printTplImports = {
+        // date(value, format)：与 amis-formula filters.date 行为对齐
+        // - 入参可以是 Date 实例 / ISO 字符串 / 时间戳数字
+        // - format 为空时默认 "YYYY-MM-DD HH:mm:ss"
+        // - date 字段 (UTC midnight) 仍按本地时区取值，与 amis 现有行为一致；
+        //   如需严格 UTC 显示请在上层 tpl 里改用 dateInput / inputFormat
+        date: function (value, format) {
+            if (value === null || value === undefined || value === '') return '';
+            const dt = value instanceof Date ? value : new Date(value);
+            if (isNaN(dt.getTime())) return String(value);
+            const f = format || 'YYYY-MM-DD HH:mm:ss';
+            const pad = (n) => (n < 10 ? '0' + n : '' + n);
+            return f
+                .replace(/YYYY/g, dt.getFullYear())
+                .replace(/MM/g, pad(dt.getMonth() + 1))
+                .replace(/DD/g, pad(dt.getDate()))
+                .replace(/HH/g, pad(dt.getHours()))
+                .replace(/mm/g, pad(dt.getMinutes()))
+                .replace(/ss/g, pad(dt.getSeconds()));
+        },
+        formatDate: function (value, format, inputFormat) {
+            return _printTplImports.date(value, format || 'YYYY-MM-DD HH:mm:ss');
+        },
+        // number(value, precision)：千分位 + 可选小数位
+        number: function (value, precision) {
+            if (value === null || value === undefined || value === '') return '';
+            const n = typeof value === 'number' ? value : Number(String(value).replace(/,/g, ''));
+            if (!isFinite(n)) return String(value);
+            if (typeof precision === 'number') {
+                return n.toLocaleString('en-US', { minimumFractionDigits: precision, maximumFractionDigits: precision });
+            }
+            const s = String(value).replace(/,/g, '');
+            const dot = s.indexOf('.');
+            const frac = dot >= 0 ? s.length - dot - 1 : 0;
+            return n.toLocaleString('en-US', { minimumFractionDigits: frac, maximumFractionDigits: Math.max(frac, 0) });
+        },
+        formatNumber: function (value, precision) {
+            return _printTplImports.number(value, precision);
+        },
+    };
     fields.forEach((f) => {
         if (f && typeof f.tpl === 'string' && f.tpl) {
             try {
                 const fn = lodashTemplate(f.tpl, {
                     variable: 'data',
                     interpolate: /<%=([\s\S]+?)%>/g,
+                    imports: _printTplImports,
                 });
                 if (typeof window !== 'undefined') {
                     window.__steedosPrintFieldTpls[tableKey + '|' + f.name] = fn;
@@ -1667,13 +1714,52 @@ const getPrintInputTableSchema = (props) => {
     const numericFieldNames = fields.filter(isThousandsField).map((f) => f.name);
     const numericFieldNamesJson = JSON.stringify(numericFieldNames);
 
+    // 图片 / 文件字段需要输出 <img> / <a> 等原始 HTML，单元格用 <%= %> 不转义；
+    // 其他字段一律 <%- %> 转义，避免文本被解释为 HTML。
+    // 上层（converter/amis/fields/file.js + AmisSteedosField.tsx）已经把
+    // 'avatar' 也走 image schema，这里把 avatar 也按 image 处理。
+    const isPrintImageType = (f) => f && (f.type === 'image' || f.type === 'avatar');
+    const isPrintFileType = (f) => f && f.type === 'file';
+    // 日期类字段：实测大量历史 instances.values 的子表行不带 _display，
+    // 服务端只回 ISO 字符串（如 "2026-02-10T00:00:00.000Z"）。打印态如果
+    // 不格式化就会原样输出 ISO，违反"与非打印态视觉一致"原则。
+    // 这里在构建期按字段类型分发到 _printTableFormatDate，运行时再决定格式。
+    const isPrintDateType = (f) => f && (f.type === 'date' || f.type === 'datetime' || f.type === 'time');
+
+    // 把每个日期字段的 format / 类型预先编码到 tpl 中（避免运行时再查 field meta）
+    // 默认 format 与 AmisSteedosField.tsx + converter/amis/fields/index.js 中的 inputFormat 对齐：
+    //   - date: YYYY-MM-DD（数据是 UTC midnight，按 UTC 取年月日，避免被时区前移一天）
+    //   - datetime: YYYY-MM-DD HH:mm（本地时区）
+    //   - time: HH:mm
+    const getPrintDateDefaultFormat = (type) => {
+        if (type === 'date') return 'YYYY-MM-DD';
+        if (type === 'datetime') return 'YYYY-MM-DD HH:mm';
+        if (type === 'time') return 'HH:mm';
+        return 'YYYY-MM-DD';
+    };
+
     const cellTemplates = fields
         .map((f) => {
             const nameJson = JSON.stringify(f.name);
-            const valueExpr = (f && typeof f.tpl === 'string' && f.tpl)
-                ? ('_printTableEvalFieldTpl(row, ' + nameJson + ')')
-                : ('_printTableFormatCell(row, ' + nameJson + ')');
-            return '<td><%- ' + valueExpr + ' %></td>';
+            let valueExpr;
+            let useRawHtml = false;
+            if (isPrintImageType(f)) {
+                valueExpr = '_printTableFormatImage(row, ' + nameJson + ')';
+                useRawHtml = true;
+            } else if (isPrintFileType(f)) {
+                valueExpr = '_printTableFormatFile(row, ' + nameJson + ')';
+                useRawHtml = true;
+            } else if (isPrintDateType(f)) {
+                const fmtJson = JSON.stringify(f.format || getPrintDateDefaultFormat(f.type));
+                const typeJson = JSON.stringify(f.type);
+                valueExpr = '_printTableFormatDate(row, ' + nameJson + ', ' + typeJson + ', ' + fmtJson + ')';
+            } else if (f && typeof f.tpl === 'string' && f.tpl) {
+                valueExpr = '_printTableEvalFieldTpl(row, ' + nameJson + ')';
+            } else {
+                valueExpr = '_printTableFormatCell(row, ' + nameJson + ')';
+            }
+            const interpolate = useRawHtml ? '<%= ' : '<%- ';
+            return '<td>' + interpolate + valueExpr + ' %></td>';
         })
         .join('');
     const indexCell = showIndex ? '<td class="steedos-print-input-table__index"><%- i + 1 %></td>' : '';
@@ -1708,26 +1794,35 @@ const getPrintInputTableSchema = (props) => {
         +   'var frac = dot >= 0 ? s.length - dot - 1 : 0; '
         +   'return n.toLocaleString("en-US", { minimumFractionDigits: frac, maximumFractionDigits: Math.max(frac, 0) }); '
         + '}; '
-        // TODO(steedos/steedos-plugins#744 follow-up): _printTableFormatCell 只覆盖了以下字段类型：
+        // 字段类型覆盖矩阵详见 .github/instructions/print-input-table.instructions.md §4
         //   ✅ text / textarea / autonumber / url / email / password —— 原值
         //   ✅ number / currency / percent（amis 中间 type=input-number）—— 千分位
         //   ✅ select / boolean / lookup（带 tpl 的）—— _printTableEvalFieldTpl 预编译求值
         //   ✅ boolean（无 tpl 兜底）—— 是 / 否
         //   ✅ 数组 / 对象 —— join(",") 或 name/label/value 取值
-        // 未覆盖（按 amis renderer static 模式行为补全，参考 node_modules/amis/src/renderers/）：
-        //   ❌ date / datetime / time —— 应按字段 format 格式化（Date.tsx）
-        //   ❌ multi-select（multiple:true）—— 应映射为 label 数组
-        //   ❌ image —— 应渲染缩略图（Image.tsx）
-        //   ❌ file —— 应渲染文件名 + 下载链接（File.tsx）
-        //   ❌ formula / summary —— 依赖服务端 _display 回填
-        //   ❌ master_detail —— 应取关联记录名称
-        //   ❌ html / markdown —— 应渲染为 DOM
-        //   ❌ color —— 应渲染色块
+        //   ✅ date / datetime / time / formula / summary / master_detail（单值）
+        //       —— 上层 Tpl.getDateTpl / getDateTimeTpl / getUiFieldTpl / getNameTpl 都返回 `${_display.<name>}`，
+        //          这里走 _display 兜底分支即对齐非打印态
+        //   ✅ multi-select / multi-lookup / multi-master_detail
+        //       —— _display 为数组时按 label/name/value 取出后 join(", ")（修复了之前把数组当对象返回空的回归）
+        //   ✅ image / avatar / multi-image —— _printTableFormatImage 输出 <img>，src 优先取 _display.url，
+        //       回退到 row[name].url，再回退到字符串原值。多图按 _display 数组逐个渲染
+        //   ✅ file / multi-file —— _printTableFormatFile 输出 <a href=url>name</a>，
+        //       字段值 / _display 同 image 处理
+        //   ⏳ html / markdown / color —— 低优先级，未覆盖；上层 readonly 模式分别走 'html' / 'static-markdown' / 'static-color'
+        //       渲染器，需要 hand-port 到 print。当前会落入字符串兜底分支，原样转义输出
         // 新增字段类型流程见 .github/instructions/print-input-table.instructions.md
         + 'var _printTableFormatCell = function(row, name){ '
         +   'if (!row) return ""; '
         +   'var d = row._display && row._display[name]; '
         +   'if (d !== null && d !== undefined && d !== "") { '
+        +     'if (Array.isArray(d)) { '
+        +       'return d.map(function(item){ '
+        +         'if (item === null || item === undefined) return ""; '
+        +         'if (typeof item === "object") return item.label || item.name || item.value || ""; '
+        +         'return String(item); '
+        +       '}).filter(function(s){ return s !== ""; }).join(", "); '
+        +     '} '
         +     'if (typeof d === "object") return d.label || d.name || d.value || ""; '
         +     'return String(d); '
         +   '} '
@@ -1746,6 +1841,87 @@ const getPrintInputTableSchema = (props) => {
         +   '} '
         +   'if (typeof v === "object") return v.name || v.label || v.value || JSON.stringify(v); '
         +   'return String(v); '
+        + '}; '
+        // HTML 转义辅助：tpl 里没法直接复用闭包外的 escapeHtmlForPrintTable，所以这里再写一份
+        + 'var _printTableEscapeHtml = function(s){ '
+        +   'if (s === null || s === undefined) return ""; '
+        +   'return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/\'/g, "&#39;"); '
+        + '}; '
+        // 图片 / 文件 字段共用的取值规范化：返回 [{url, name}] 数组
+        // 优先用 _display[name]（服务端通常已注入 {url, name, value}），
+        // 兜底用 row[name] 自身（可能是字符串 URL / {url} / 数组）
+        + 'var _printTableNormalizeFiles = function(row, name){ '
+        +   'var pick = function(it){ '
+        +     'if (it === null || it === undefined) return null; '
+        +     'if (typeof it === "string") return { url: it, name: it }; '
+        +     'if (typeof it === "object") { '
+        +       'var url = it.url || it.src || it.value || ""; '
+        +       'var label = it.name || it.label || ""; '
+        +       'if (!url && !label) return null; '
+        +       'return { url: url, name: label || url }; '
+        +     '} '
+        +     'return null; '
+        +   '}; '
+        +   'var src = (row && row._display && row._display[name]); '
+        +   'if (src === null || src === undefined || src === "") { src = row ? row[name] : null; } '
+        +   'if (src === null || src === undefined || src === "") return []; '
+        +   'var arr = Array.isArray(src) ? src : [src]; '
+        +   'var out = []; '
+        +   'for (var i = 0; i < arr.length; i++) { var picked = pick(arr[i]); if (picked) out.push(picked); } '
+        +   'return out; '
+        + '}; '
+        // 打印态图片：固定缩略尺寸（max-height:60px / max-width:120px），避免高分图片把行撑爆
+        // 多图横向排列，间距 4px
+        + 'var _printTableFormatImage = function(row, name){ '
+        +   'var items = _printTableNormalizeFiles(row, name); '
+        +   'if (!items.length) return ""; '
+        +   'return items.map(function(it){ '
+        +     'var url = _printTableEscapeHtml(it.url); '
+        +     'var alt = _printTableEscapeHtml(it.name || ""); '
+        +     'if (!url) return ""; '
+        +     'return "<img src=\\"" + url + "\\" alt=\\"" + alt + "\\" class=\\"steedos-print-input-table__img\\" />"; '
+        +   '}).join(""); '
+        + '}; '
+        // 打印态文件：文件名 + 下载链接；多文件用空格 + 换行分隔
+        + 'var _printTableFormatFile = function(row, name){ '
+        +   'var items = _printTableNormalizeFiles(row, name); '
+        +   'if (!items.length) return ""; '
+        +   'return items.map(function(it){ '
+        +     'var url = _printTableEscapeHtml(it.url); '
+        +     'var label = _printTableEscapeHtml(it.name || it.url || ""); '
+        +     'if (!url) return label; '
+        +     'return "<a href=\\"" + url + "\\" target=\\"_blank\\" class=\\"steedos-print-input-table__file\\">" + label + "</a>"; '
+        +   '}).join(" "); '
+        + '}; '
+        // 打印态日期：按字段 format 格式化 ISO 字符串 / Date 对象
+        // 设计要点：
+        //   1. 服务端对 date / datetime 子表行通常不回 _display，只回 ISO 字符串
+        //      （如 "2026-02-10T00:00:00.000Z"），打印态如果不格式化就会原样输出
+        //   2. 与 amis 行为对齐：date 字段的 ISO 是 UTC midnight，必须按 UTC 取
+        //      年月日；否则东 8 区会把 2026-02-10 显示成 2026-02-09
+        //   3. format 支持的 token：YYYY, MM, DD, HH, mm, ss（再保留原值的其它字符）
+        //      这与 Steedos 上下游配置 (inputFormat: "YYYY-MM-DD" / "YYYY-MM-DD HH:mm") 一致
+        + 'var _printTableFormatDate = function(row, name, ftype, fmt){ '
+        +   'if (!row) return ""; '
+        +   'var d = row._display && row._display[name]; '
+        +   'if (d !== null && d !== undefined && d !== "") { '
+        +     'if (typeof d === "string" || typeof d === "number") return String(d); '
+        +     'if (typeof d === "object") return d.label || d.name || d.value || ""; '
+        +   '} '
+        +   'var v = row[name]; '
+        +   'if (v === null || v === undefined || v === "") return ""; '
+        +   'var dt = (v instanceof Date) ? v : new Date(v); '
+        +   'if (isNaN(dt.getTime())) return String(v); '
+        +   'var useUTC = (ftype === "date"); '
+        +   'var pad = function(n){ return n < 10 ? "0" + n : "" + n; }; '
+        +   'var yyyy = useUTC ? dt.getUTCFullYear() : dt.getFullYear(); '
+        +   'var MM = pad((useUTC ? dt.getUTCMonth() : dt.getMonth()) + 1); '
+        +   'var DD = pad(useUTC ? dt.getUTCDate() : dt.getDate()); '
+        +   'var HH = pad(useUTC ? dt.getUTCHours() : dt.getHours()); '
+        +   'var mm = pad(useUTC ? dt.getUTCMinutes() : dt.getMinutes()); '
+        +   'var ss = pad(useUTC ? dt.getUTCSeconds() : dt.getSeconds()); '
+        +   'var f = fmt || "YYYY-MM-DD"; '
+        +   'return f.replace(/YYYY/g, yyyy).replace(/MM/g, MM).replace(/DD/g, DD).replace(/HH/g, HH).replace(/mm/g, mm).replace(/ss/g, ss); '
         + '}; '
         + 'var _printTableEvalFieldTpl = function(row, name){ '
         +   'try { '

--- a/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
@@ -1609,11 +1609,19 @@ const escapeHtmlForPrintTable = (text) => {
 
 // 将子表渲染为纯静态 HTML 表格，绕开 amis input-table / antd Table 的复杂 DOM
 // 表头取 field.label，行值直接取 row[field.name]；select / lookup 暂走基础格式化
+// 数值 / 金额 / 日期 等非文本类字段不按字符断行，避免"23232"被竖排折成"2/3/2/3/2"
+const isPrintInputTableNoWrapType = (type) => {
+    return /^(number|currency|percent|date|datetime|time)$/.test(type || '');
+};
+
 const getPrintInputTableSchema = (props) => {
     const fields = (props.fields || []).filter((f) => f && f.name);
     const showIndex = props.showIndex !== false;
     const visibleFieldNames = fields.map((f) => f.name);
 
+    // 注意：进入打印链路时 props.fields[*].type 已被上层转成 amis 的 'static' / 'input-number' 等，
+    // 不再是 Steedos 原 'number'/'currency'/'date'。因此 nowrap class 与千分位等需要
+    // 在 tpl 运行时按 row[name] 实际值类型判断，不在 schema 生成期按字段 type 判断。
     const headerCells = [];
     if (showIndex) {
         headerCells.push('<th class="steedos-print-input-table__index">#</th>');
@@ -1626,7 +1634,11 @@ const getPrintInputTableSchema = (props) => {
     const visibleFieldNamesJson = JSON.stringify(visibleFieldNames);
 
     const cellTemplates = fields
-        .map((f) => '<td><%- _printTableFormatCell(row, ' + JSON.stringify(f.name) + ') %></td>')
+        .map((f) => {
+            const nameJson = JSON.stringify(f.name);
+            // class 用 <%= %>（不转义）避免双引号变 &quot;；cell 值用 <%- %> 防 XSS
+            return '<td<%= _printTableCellClass(row, ' + nameJson + ') %>><%- _printTableFormatCell(row, ' + nameJson + ') %></td>';
+        })
         .join('');
     const indexCell = showIndex ? '<td class="steedos-print-input-table__index"><%- i + 1 %></td>' : '';
 
@@ -1636,13 +1648,56 @@ const getPrintInputTableSchema = (props) => {
         + '<thead><tr>' + headerCells.join('') + '</tr></thead>'
         + '<tbody>'
         + '<% '
+        // 注意：本 tpl 由若干 '...' 字符串用 + 拼接而成，
+        // 行尾不可写 // 行内注释——否则 `+ // comment` 会让下一行开头的
+        // `+'string'` 退化为一元 `+`，把字符串转成 NaN 注入到 tpl 里。
+        // 另外：tpl 字符串中 **绝对不要出现裸的 `$` 字符**（除非紧跟在 `\\` 后面）。
+        // amis 内置 tpl 引擎(builtin)会优先匹配带 `$` 的模板，从而抢占 lodash 引擎，
+        // 导致 `<% %>` 块被完全忽略且最终返回空。这是数值正则 `/^...$/` 一开始失效的根因。
+        // 所有说明请放在拼接表达式上方，不要写在 + 之间。
         + 'var _printTableRows = (data && data[' + rowsExpr + ']) || []; '
         + 'var _printTableVisibleFields = ' + visibleFieldNamesJson + '; '
+        + 'var _printTableIsNumericValue = function(v){ '
+        +   'if (typeof v === "number") return isFinite(v); '
+        +   'if (typeof v !== "string" || v === "") return false; '
+        +   'var s = v.replace(/,/g, ""); '
+        +   'if (s.charAt(0) === "-") s = s.slice(1); '
+        +   'if (s === "" || s === ".") return false; '
+        +   'var dotSeen = false; '
+        +   'for (var i = 0; i < s.length; i++) { '
+        +     'var c = s.charCodeAt(i); '
+        +     'if (c === 46) { if (dotSeen) return false; dotSeen = true; continue; } '
+        +     'if (c < 48 || c > 57) return false; '
+        +   '} '
+        +   'return isFinite(Number(v.replace(/,/g, ""))); '
+        + '}; '
+        + 'var _printTableFormatNumber = function(v){ '
+        +   'var n = typeof v === "number" ? v : Number(String(v).replace(/,/g, "")); '
+        +   'if (!isFinite(n)) return String(v); '
+        +   'var s = String(v).replace(/,/g, ""); '
+        +   'var dot = s.indexOf("."); '
+        +   'var frac = dot >= 0 ? s.length - dot - 1 : 0; '
+        +   'return n.toLocaleString("en-US", { minimumFractionDigits: frac, maximumFractionDigits: Math.max(frac, 0) }); '
+        + '}; '
+        + 'var _printTableCellClass = function(row, name){ '
+        +   'if (!row) return ""; '
+        +   'var d = row._display && row._display[name]; '
+        +   'var v = (d !== null && d !== undefined && d !== "") ? d : row[name]; '
+        +   'if (_printTableIsNumericValue(v)) return " class=\\"steedos-print-input-table__nowrap\\""; '
+        +   'return ""; '
+        + '}; '
         + 'var _printTableFormatCell = function(row, name){ '
         +   'if (!row) return ""; '
+        +   'var d = row._display && row._display[name]; '
+        +   'if (d !== null && d !== undefined && d !== "") { '
+        +     'if (typeof d === "object") return d.label || d.name || d.value || ""; '
+        +     'var ds = String(d); '
+        +     'return _printTableIsNumericValue(ds) ? _printTableFormatNumber(ds) : ds; '
+        +   '} '
         +   'var v = row[name]; '
         +   'if (v === null || v === undefined) return ""; '
         +   'if (typeof v === "boolean") return v ? "是" : "否"; '
+        +   'if (_printTableIsNumericValue(v)) return _printTableFormatNumber(v); '
         +   'if (Array.isArray(v)) { '
         +     'return v.map(function(item){ '
         +       'if (item && typeof item === "object") return item.name || item.label || item.value || JSON.stringify(item); '

--- a/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
@@ -1577,7 +1577,116 @@ async function getButtonDelete(props) {
 }
 
 
+// 子表打印渲染器开关（issue steedos/steedos-plugins#744 子表打印线条失真）
+// 命中条件（满足任一即可）：
+//   1. props.print === true（上层显式声明，预留链路）
+//   2. 当前 URL pathname 包含 /page/page_instance_print（审批打印页，稳定标识）
+//   3. localStorage.STEEDOS_PRINT_INPUT_TABLE = '1'（调试 / 灰度兜底，可移除）
+// 命中后 getAmisInputTableSchema 会绕开 amis input-table / antd Table，
+// 改用纯静态 HTML 表格渲染，彻底规避超宽列布局导致的文字压扁失真问题。
+const isPrintInputTableEnabled = (props) => {
+    try {
+        if (props && props.print === true) return true;
+        if (typeof window === 'undefined') return false;
+        const pathname = (window.location && window.location.pathname) || '';
+        if (/\/page\/page_instance_print(\/|$)/.test(pathname)) return true;
+        if (window.localStorage && window.localStorage.STEEDOS_PRINT_INPUT_TABLE === '1') return true;
+    } catch (e) {
+        // 任意环境异常都视为未开启，回落到原 amis input-table 路径
+    }
+    return false;
+};
+
+const escapeHtmlForPrintTable = (text) => {
+    if (text === null || text === undefined) return '';
+    return String(text)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+};
+
+// 将子表渲染为纯静态 HTML 表格，绕开 amis input-table / antd Table 的复杂 DOM
+// 表头取 field.label，行值直接取 row[field.name]；select / lookup 暂走基础格式化
+const getPrintInputTableSchema = (props) => {
+    const fields = (props.fields || []).filter((f) => f && f.name);
+    const showIndex = props.showIndex !== false;
+    const visibleFieldNames = fields.map((f) => f.name);
+
+    const headerCells = [];
+    if (showIndex) {
+        headerCells.push('<th class="steedos-print-input-table__index">#</th>');
+    }
+    fields.forEach((f) => {
+        headerCells.push('<th>' + escapeHtmlForPrintTable(f.label || f.name) + '</th>');
+    });
+
+    const rowsExpr = JSON.stringify(props.name);
+    const visibleFieldNamesJson = JSON.stringify(visibleFieldNames);
+
+    const cellTemplates = fields
+        .map((f) => '<td><%- _printTableFormatCell(row, ' + JSON.stringify(f.name) + ') %></td>')
+        .join('');
+    const indexCell = showIndex ? '<td class="steedos-print-input-table__index"><%- i + 1 %></td>' : '';
+
+    // 样式已迁移到 packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
+    const tpl = '<div class="steedos-print-input-table-wrap" data-name="' + escapeHtmlForPrintTable(props.name) + '">'
+        + '<table class="steedos-print-input-table">'
+        + '<thead><tr>' + headerCells.join('') + '</tr></thead>'
+        + '<tbody>'
+        + '<% '
+        + 'var _printTableRows = (data && data[' + rowsExpr + ']) || []; '
+        + 'var _printTableVisibleFields = ' + visibleFieldNamesJson + '; '
+        + 'var _printTableFormatCell = function(row, name){ '
+        +   'if (!row) return ""; '
+        +   'var v = row[name]; '
+        +   'if (v === null || v === undefined) return ""; '
+        +   'if (typeof v === "boolean") return v ? "是" : "否"; '
+        +   'if (Array.isArray(v)) { '
+        +     'return v.map(function(item){ '
+        +       'if (item && typeof item === "object") return item.name || item.label || item.value || JSON.stringify(item); '
+        +       'return String(item); '
+        +     '}).join(", "); '
+        +   '} '
+        +   'if (typeof v === "object") return v.name || v.label || v.value || JSON.stringify(v); '
+        +   'return String(v); '
+        + '}; '
+        + '_printTableRows.forEach(function(row, i){ '
+        + '%>'
+        + '<tr>' + indexCell + cellTemplates + '</tr>'
+        + '<% }); %>'
+        + '</tbody>'
+        + '</table>'
+        + '</div>';
+
+    return {
+        type: 'control',
+        label: props.label,
+        labelClassName: props.label ? props.labelClassName : 'none',
+        labelRemark: props.labelRemark,
+        labelAlign: props.labelAlign,
+        mode: props.mode || null,
+        visibleOn: props.$schema && props.$schema.visibleOn,
+        visible: props.$schema && props.$schema.visible,
+        hiddenOn: props.$schema && props.$schema.hiddenOn,
+        hidden: props.$schema && props.$schema.hidden,
+        required: props.required,
+        className: 'steedos-input-table steedos-print-input-table-host',
+        body: {
+            type: 'tpl',
+            tpl,
+            className: 'steedos-print-input-table-tpl',
+        },
+    };
+};
+
 export const getAmisInputTableSchema = async (props) => {
+    // 命中打印场景时直接走纯静态 HTML 表格渲染器，绕过 amis input-table → antd Table 复杂 DOM，
+    // 修复 A4 打印下子表线条 / 文字被压缩失真的问题（steedos/steedos-plugins#744）
+    if (isPrintInputTableEnabled(props)) {
+        return getPrintInputTableSchema(props);
+    }
     if (!props.id) {
         props.id = "steedos_input_table_" + props.name + "_" + Math.random().toString(36).substr(2, 9);
     }

--- a/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
@@ -1621,19 +1621,14 @@ const getPrintInputTableSchema = (props) => {
 
     // 字段在进入打印链路时已被上层转换成 amis 形式：
     // - readonly 文本类: { type: 'static', className: '...steedos-field-input-readonly' }
-    // - readonly 数字类: { type: 'static', className: '...steedos-field-number-readonly' }
-    //   或 { type: 'input-number', static: true, precision: ... }
+    // - readonly number 字段未配 precision: { type: 'static', className: '...steedos-field-number-readonly' }
+    //   → 非打印态 amis 渲染原值（无千分位），打印态对齐
+    // - readonly currency / 配 precision 的 number: { type: 'input-number', static: true, precision: 'N' }
+    //   → 非打印态 amis input-number 在 static 模式下按 precision 千分位渲染，打印态对齐
     // - readonly 选项类: { type: 'static', className: '...steedos-field-select-readonly', tpl: '<% ... %>' }
-    // 因此判定方式：
-    //   nowrap   ← className 含 'steedos-field-number-readonly' 或 type === 'input-number'
-    //   渲染值   ← 有 tpl 时用 lodash.template 求值（对齐非打印态 static-tpl 行为），否则取 _display[name] 或 row[name]
-    // 千分位不在此处加工，完全对齐非打印态（非打印态依赖服务端 _display，子表通常没有）。
-    const isNumericField = (f) => {
-        if (!f) return false;
-        if (f.type === 'input-number') return true;
-        const cls = typeof f.className === 'string' ? f.className : '';
-        return cls.indexOf('steedos-field-number-readonly') !== -1;
-    };
+    //   → 非打印态用 lodash 模板把值映射为 label，打印态按 row 求值同一 tpl
+    // 不再为打印态额外加 nowrap class —— 非打印态没有，规则保持一致。
+    const isThousandsField = (f) => !!(f && f.type === 'input-number');
 
     // 把 tpl 字段的 lodash 模板预编译并以 window 全局表暂存，运行时按 (tableKey|fieldName) 查找调用。
     // 与 amis 内置 tpl-lodash 引擎一致：variable: 'data'，使得 tpl 内的 data["xxx"] 等价于 row["xxx"]。
@@ -1668,20 +1663,17 @@ const getPrintInputTableSchema = (props) => {
     const rowsExpr = JSON.stringify(props.name);
     const visibleFieldNamesJson = JSON.stringify(visibleFieldNames);
 
-    // 数值字段名集合（用于 tpl 内运行时判定是否需要千分位）
-    const numericFieldNames = fields.filter(isNumericField).map((f) => f.name);
+    // 需要千分位的字段名集合（仅 input-number 类型）
+    const numericFieldNames = fields.filter(isThousandsField).map((f) => f.name);
     const numericFieldNamesJson = JSON.stringify(numericFieldNames);
 
     const cellTemplates = fields
         .map((f) => {
             const nameJson = JSON.stringify(f.name);
-            const cellClass = isNumericField(f)
-                ? ' class="steedos-print-input-table__nowrap"'
-                : '';
             const valueExpr = (f && typeof f.tpl === 'string' && f.tpl)
                 ? ('_printTableEvalFieldTpl(row, ' + nameJson + ')')
                 : ('_printTableFormatCell(row, ' + nameJson + ')');
-            return '<td' + cellClass + '><%- ' + valueExpr + ' %></td>';
+            return '<td><%- ' + valueExpr + ' %></td>';
         })
         .join('');
     const indexCell = showIndex ? '<td class="steedos-print-input-table__index"><%- i + 1 %></td>' : '';

--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -1782,30 +1782,6 @@ export const getFlowFormSchema = async (instance, box, print) => {
     }
   }
 
-  // 打印态收口：递归把 instanceFormSchema 内所有 steedos-input-table 节点强制标 print:true。
-  // 覆盖 instance_template (JSON 自定义模板) / liquid 模板等 path —— 这些 path 不经过
-  // normalizeLegacyPrintFields，无法在 field._print 上做标记。
-  // v1 路径已通过 case "table" / getFieldReadonlyTpl 单独写入 tpl.print，此处再走一次也无副作用。
-  // v2 路径子表由 React (SubTablePreview) 渲染，不在此 schema 树内，不受影响。
-  // 详见 steedos/steedos-plugins#744。
-  if (print && instanceFormSchema) {
-    const markPrint = (node) => {
-      if (!node || typeof node !== 'object') return;
-      if (Array.isArray(node)) {
-        node.forEach(markPrint);
-        return;
-      }
-      if (node.type === 'steedos-input-table') {
-        node.print = true;
-      }
-      // amis schema 常见子节点字段
-      ['body', 'fields', 'columns', 'controls', 'tabs', 'items'].forEach((k) => {
-        if (node[k]) markPrint(node[k]);
-      });
-    };
-    markPrint(instanceFormSchema);
-  }
-
   console.log('instanceFormSchema....', instanceFormSchema)
   return {
     type: "page",

--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -1591,23 +1591,37 @@ export const getFlowFormSchema = async (instance, box, print) => {
   }
   let formContentSchema;
   let instanceFormSchema;
+  // 打印模式下，给自定义模板字符串里嵌入的 steedos-input-table schema 注入 print:true。
+  // print_template / instance_template 由后端 templateConverter 把字段 def 序列化为
+  // amis JSON 嵌入 HTML 模板字符串，前端走 liquid 二次 mount，walker 进不到字符串内部。
+  // 详见 steedos/steedos-plugins#744。
+  const injectPrintInInputTable = (tplStr) => {
+    if (!tplStr || typeof tplStr !== 'string') return tplStr;
+    // 已经标过则不再追加；只匹配尚未含 "print" 紧邻 key 的位置
+    return tplStr.replace(
+      /"type"\s*:\s*"steedos-input-table"/g,
+      '"type":"steedos-input-table","print":true'
+    );
+  };
   if(print && instance.flow.print_template){
+    const tpl = injectPrintInInputTable(instance.flow.print_template);
     try {
-      instanceFormSchema = JSON.parse(instance.flow.print_template);
+      instanceFormSchema = JSON.parse(tpl);
     } catch (error) {
       instanceFormSchema = {
         type: 'liquid',
-        template: instance.flow.print_template
+        template: tpl
       }
     }
   }else{
     if(!isMobile && instance.flow.instance_template && instance.formVersion.version != 'v2'){
+      const tpl = print ? injectPrintInInputTable(instance.flow.instance_template) : instance.flow.instance_template;
       try {
-        formContentSchema = JSON.parse(instance.flow.instance_template);
+        formContentSchema = JSON.parse(tpl);
       } catch (error) {
         formContentSchema = {
           type: 'liquid',
-          template: instance.flow.instance_template
+          template: tpl
         }
       }
     }else{
@@ -1766,6 +1780,30 @@ export const getFlowFormSchema = async (instance, box, print) => {
             }
           };
     }
+  }
+
+  // 打印态收口：递归把 instanceFormSchema 内所有 steedos-input-table 节点强制标 print:true。
+  // 覆盖 instance_template (JSON 自定义模板) / liquid 模板等 path —— 这些 path 不经过
+  // normalizeLegacyPrintFields，无法在 field._print 上做标记。
+  // v1 路径已通过 case "table" / getFieldReadonlyTpl 单独写入 tpl.print，此处再走一次也无副作用。
+  // v2 路径子表由 React (SubTablePreview) 渲染，不在此 schema 树内，不受影响。
+  // 详见 steedos/steedos-plugins#744。
+  if (print && instanceFormSchema) {
+    const markPrint = (node) => {
+      if (!node || typeof node !== 'object') return;
+      if (Array.isArray(node)) {
+        node.forEach(markPrint);
+        return;
+      }
+      if (node.type === 'steedos-input-table') {
+        node.print = true;
+      }
+      // amis schema 常见子节点字段
+      ['body', 'fields', 'columns', 'controls', 'tabs', 'items'].forEach((k) => {
+        if (node[k]) markPrint(node[k]);
+      });
+    };
+    markPrint(instanceFormSchema);
   }
 
   console.log('instanceFormSchema....', instanceFormSchema)

--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -37,6 +37,11 @@ const normalizeLegacyPrintFields = (fields) => {
       return;
     }
     field.permission = 'readonly';
+    // 标记子表字段进入打印态，case "table" 会读取此标记并写入子表 schema.print，
+    // 让 getAmisInputTableSchema 走纯静态 HTML 打印渲染器（steedos/steedos-plugins#744）。
+    if (field.type === 'table') {
+      field._print = true;
+    }
     // section 嵌套字段 / table 子字段
     if (Array.isArray(field.fields)) {
       normalizeLegacyPrintFields(field.fields);
@@ -599,6 +604,12 @@ const getFieldEditTpl = async (field, label, inTable, tableFieldMap)=>{
       //   break;
       case "table":
         tpl.type = "steedos-input-table";
+        // 打印态：normalizeLegacyPrintFields 已给 table 字段标记 _print=true，
+        // 这里写入子表 schema.print，让 getAmisInputTableSchema 走静态 HTML 打印渲染器
+        // （steedos/steedos-plugins#744）。
+        if (field._print) {
+          tpl.print = true;
+        }
         tpl.addable = field.permission === "editable";
         tpl.editable = tpl.addable;
         tpl.removable = tpl.addable;
@@ -827,6 +838,10 @@ const getFieldReadonlyTpl = async (field, label, inTable, tableFieldMap)=>{
 
   }else if(field.type === 'table'){
     tpl.type = "steedos-input-table";
+    // 打印态：参考 case "table" 同步逻辑（steedos/steedos-plugins#744）
+    if (field._print) {
+      tpl.print = true;
+    }
     tpl.disabled = true;
     tpl.autoGeneratePrimaryKeyValue = true;
     tpl.fields = [];

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
@@ -179,6 +179,22 @@
     margin: 0 !important;
     padding: 0 !important;
   }
+
+  // 屏幕预览态：审批打印页外层是传统 HTML <table class="form-table"> 布局，
+  // 按 td 的 max-content 计算列宽。子表 <table min-width:max-content> 会
+  // 把所在的 td 撑到子表自然宽度，进而把整个审批单撑爆，最外层出现页面级
+  // 横向滚动条（issue steedos/steedos-plugins#744 二阶段回归）。
+  // 用 contain: inline-size 切断"子树 max-content → 父 td 列宽"的传递，
+  // 让 host 的横向尺寸只由父链决定，不被子表内部反向撑大；
+  // 这样 wrap 的 overflow-x:auto 才能在内部真正触发独立横向滚动条。
+  @media screen {
+    contain: inline-size;
+    max-width: 100%;
+  }
+  // 打印态：保留默认行为，让 chrome 打印引擎按 A4 物理宽度自然处理
+  @media print {
+    contain: none;
+  }
 }
 
 .steedos-print-input-table {
@@ -188,6 +204,18 @@
   table-layout: auto;
   border-collapse: collapse;
   color: #000;
+
+  // 屏幕预览态：强制 table 主张自己的最小内容宽度（不被 wrap 压缩），
+  // 超宽时才能触发 .steedos-print-input-table-wrap 的 overflow-x:auto 滚动条；
+  // 否则 table-layout:auto 会让浏览器把列压缩到适应 wrap，单元格内容被强行竖排。
+  // 对齐非打印态 antd Table 的 min-width 行为
+  @media screen {
+    min-width: max-content;
+  }
+  // 打印态：让 chrome 打印引擎按 A4 物理宽度自然压缩（已知 A4 物理极限）
+  @media print {
+    min-width: 0;
+  }
 
   th,
   td {

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
@@ -157,6 +157,14 @@
 // 仅在审批打印页（/page/page_instance_print）生效，绕开 antd Table，输出纯静态 HTML 表格
 .steedos-print-input-table-wrap {
   width: 100%;
+  // 屏幕预览态：当子表列总宽超过容器时，由 wrap 自身出水平滚动条，
+  // 避免内容把外层审批单一路撑宽 → 最外层页面级横向滚动条（对齐非打印态 antd Table 行为）
+  overflow-x: auto;
+  // 打印态：让 chrome 打印引擎按 A4 物理宽度自然处理（截断 / 缩放），
+  // 不要保留 scroll 容器（打印时 overflow:auto 会变 hidden 反而丢内容）
+  @media print {
+    overflow-x: visible;
+  }
 }
 
 // 抵消外层 amis form-item / form-control 默认 margin/padding，避免子表上下出现空白

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
@@ -159,41 +159,71 @@
   width: 100%;
 }
 
+// 抵消外层 amis form-item / form-control 默认 margin/padding，避免子表上下出现空白
+.steedos-print-input-table-host {
+  margin: 0 !important;
+  padding: 0 !important;
+
+  .antd-Form-control,
+  .antd-Form-value,
+  .antd-Form-item-content,
+  .antd-Form-itemColumn {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+}
+
 .steedos-print-input-table {
   width: 100%;
-  table-layout: fixed;
+  // table-layout: auto 让列宽按内容自适应，避免 fixed + 等宽导致数字短串(如 "23232")
+  // 被挤窄到不下被 overflow-wrap 按字符强制断行（详情页 antd Table 默认就是 auto）
+  table-layout: auto;
   border-collapse: collapse;
-  border: 0;
   color: #000;
 
   th,
   td {
-    border-right: 1px solid #000;
-    border-bottom: 1px solid #000;
+    border: 1px solid #000;
     padding: 4px 6px;
     vertical-align: top;
-    word-break: break-word;
-    overflow-wrap: anywhere;
+    // 仅做"长单词最终兜底"，不开 anywhere；中文天然可按字断行，
+    // 数字 / 英文短串在 table-layout: auto 下列宽自适应，不会再被错切
+    word-break: normal;
+    overflow-wrap: break-word;
     font-size: 14px;
     line-height: 1.4;
     text-align: left;
+    font-weight: inherit;
   }
 
-  thead th {
-    background: transparent;
-    font-weight: 600;
+  // 去掉子表自身 4 个外边，避免与外层表单容器边框叠成双线
+  // 内部 cell 之间的边框由 border-collapse 自动合并，仍然闭合
+  thead tr:first-child > th {
+    border-top: 0;
   }
-
+  tbody tr:last-child > td {
+    border-bottom: 0;
+  }
+  tr > :first-child {
+    border-left: 0;
+  }
   tr > :last-child {
     border-right: 0;
   }
 
-  tbody tr:last-child > td {
-    border-bottom: 0;
+  thead th {
+    background: transparent;
   }
 
   .steedos-print-input-table__index {
     width: 40px;
     text-align: center;
+  }
+
+  // 数值 / 金额 / 日期 等非文本类字段：不按字符断行，避免数字被竖排折断
+  .steedos-print-input-table__nowrap {
+    word-break: keep-all;
+    overflow-wrap: normal;
+    white-space: nowrap;
   }
 }

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
@@ -157,10 +157,29 @@
 // 仅在审批打印页（/page/page_instance_print）生效，绕开 antd Table，输出纯静态 HTML 表格
 .steedos-print-input-table-wrap {
   width: 100%;
-  // 当子表列总宽超过容器时，由 wrap 自身出横向滚动条（屏幕态可滚动查看；
-  // 打印态 chrome 不会渲染滚动条本身，但 overflow:auto 不会丢内容，超出部分
-  // 按 A4 物理宽度自然截断到纸张右侧 —— 与非打印态 antd Table 一致）
-  overflow-x: auto;
+  // 当子表列总宽超过容器时，由 wrap 自身出横向滚动条。
+  // 用 scroll 而非 auto 的原因：chrome 真打印预览（@media print）下，
+  // overflow:auto 即使有溢出也常常不渲染滚动条 UI（chrome 认为纸张上
+  // 滚动条不可交互所以省略），导致用户在真打印预览看不到"右侧还有内容"
+  // 的视觉提示。改成 scroll 后 chrome 会把滚动条 track 当成实际内容
+  // 一起渲染到打印预览页面右侧 → 起到"右侧被截断"的指示作用
+  // （issue steedos/steedos-plugins#744 真打印态滚动条指示）。
+  overflow-x: scroll;
+  overflow-y: hidden;
+  // 自定义 webkit 滚动条样式，确保打印预览里也能看见浅灰 track + 深灰 thumb
+  // chrome 打印引擎尊重 ::-webkit-scrollbar 自定义样式；如果只依赖系统默认
+  // overlay 滚动条（macOS），打印预览可能完全空白看不到指示
+  &::-webkit-scrollbar {
+    height: 8px;
+    -webkit-appearance: none;
+  }
+  &::-webkit-scrollbar-track {
+    background: #f1f1f1;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: #888;
+    border-radius: 4px;
+  }
 }
 
 // 抵消外层 amis form-item / form-control 默认 margin/padding，避免子表上下出现空白

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
@@ -278,4 +278,30 @@
     overflow-wrap: normal;
     white-space: nowrap;
   }
+
+  // 打印态图片字段：固定缩略尺寸，避免高分图把行撑爆；多图横排
+  // 对应 _printTableFormatImage 输出的 <img class="steedos-print-input-table__img"/>
+  .steedos-print-input-table__img {
+    display: inline-block;
+    max-height: 60px;
+    max-width: 120px;
+    object-fit: contain;
+    margin: 2px 4px 2px 0;
+    vertical-align: middle;
+  }
+
+  // 打印态文件字段：保留下载链接样式（蓝色下划线），多文件以空格分隔
+  // 对应 _printTableFormatFile 输出的 <a class="steedos-print-input-table__file">
+  .steedos-print-input-table__file {
+    color: #1d4ed8;
+    text-decoration: underline;
+    word-break: break-all;
+    margin-right: 6px;
+
+    // 真打印：不必再保留 link 样式（用户拿不到 hover/click），保持可读即可
+    @media print {
+      color: inherit;
+      text-decoration: none;
+    }
+  }
 }

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
@@ -152,3 +152,48 @@
   white-space: nowrap;
   word-break: normal;
 }
+
+// 子表打印渲染器（issue steedos/steedos-plugins#744 子表打印线条失真）
+// 仅在审批打印页（/page/page_instance_print）生效，绕开 antd Table，输出纯静态 HTML 表格
+.steedos-print-input-table-wrap {
+  width: 100%;
+}
+
+.steedos-print-input-table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  border: 0;
+  color: #000;
+
+  th,
+  td {
+    border-right: 1px solid #000;
+    border-bottom: 1px solid #000;
+    padding: 4px 6px;
+    vertical-align: top;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+    font-size: 14px;
+    line-height: 1.4;
+    text-align: left;
+  }
+
+  thead th {
+    background: transparent;
+    font-weight: 600;
+  }
+
+  tr > :last-child {
+    border-right: 0;
+  }
+
+  tbody tr:last-child > td {
+    border-bottom: 0;
+  }
+
+  .steedos-print-input-table__index {
+    width: 40px;
+    text-align: center;
+  }
+}

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
@@ -157,14 +157,10 @@
 // 仅在审批打印页（/page/page_instance_print）生效，绕开 antd Table，输出纯静态 HTML 表格
 .steedos-print-input-table-wrap {
   width: 100%;
-  // 屏幕预览态：当子表列总宽超过容器时，由 wrap 自身出水平滚动条，
-  // 避免内容把外层审批单一路撑宽 → 最外层页面级横向滚动条（对齐非打印态 antd Table 行为）
+  // 当子表列总宽超过容器时，由 wrap 自身出横向滚动条（屏幕态可滚动查看；
+  // 打印态 chrome 不会渲染滚动条本身，但 overflow:auto 不会丢内容，超出部分
+  // 按 A4 物理宽度自然截断到纸张右侧 —— 与非打印态 antd Table 一致）
   overflow-x: auto;
-  // 打印态：让 chrome 打印引擎按 A4 物理宽度自然处理（截断 / 缩放），
-  // 不要保留 scroll 容器（打印时 overflow:auto 会变 hidden 反而丢内容）
-  @media print {
-    overflow-x: visible;
-  }
 }
 
 // 抵消外层 amis form-item / form-control 默认 margin/padding，避免子表上下出现空白
@@ -180,21 +176,20 @@
     padding: 0 !important;
   }
 
-  // 屏幕预览态：审批打印页外层是传统 HTML <table class="form-table"> 布局，
+  // 审批打印页外层是传统 HTML <table class="form-table"> 布局，
   // 按 td 的 max-content 计算列宽。子表 <table min-width:max-content> 会
   // 把所在的 td 撑到子表自然宽度，进而把整个审批单撑爆，最外层出现页面级
   // 横向滚动条（issue steedos/steedos-plugins#744 二阶段回归）。
   // 用 contain: inline-size 切断"子树 max-content → 父 td 列宽"的传递，
   // 让 host 的横向尺寸只由父链决定，不被子表内部反向撑大；
   // 这样 wrap 的 overflow-x:auto 才能在内部真正触发独立横向滚动条。
-  @media screen {
-    contain: inline-size;
-    max-width: 100%;
-  }
-  // 打印态：保留默认行为，让 chrome 打印引擎按 A4 物理宽度自然处理
-  @media print {
-    contain: none;
-  }
+  // ⚠️ 打印态 (@media print) 必须保留 contain，不能切回 none：
+  //   一旦切掉，table 的 max-content 又会反向撑大 td → 整张审批单被压缩
+  //   到 A4 宽度 → 子表所有列被等比挤窄 → 表头文字按字符竖排断行。
+  //   保留 contain 后，chrome 打印按 A4 截断子表右侧超出部分（已知 A4 物理
+  //   极限），但列宽与屏幕预览一致、文字不竖排，与非打印态 antd Table 行为对齐。
+  contain: inline-size;
+  max-width: 100%;
 }
 
 .steedos-print-input-table {
@@ -205,17 +200,14 @@
   border-collapse: collapse;
   color: #000;
 
-  // 屏幕预览态：强制 table 主张自己的最小内容宽度（不被 wrap 压缩），
-  // 超宽时才能触发 .steedos-print-input-table-wrap 的 overflow-x:auto 滚动条；
-  // 否则 table-layout:auto 会让浏览器把列压缩到适应 wrap，单元格内容被强行竖排。
-  // 对齐非打印态 antd Table 的 min-width 行为
-  @media screen {
-    min-width: max-content;
-  }
-  // 打印态：让 chrome 打印引擎按 A4 物理宽度自然压缩（已知 A4 物理极限）
-  @media print {
-    min-width: 0;
-  }
+  // 强制 table 主张自己的最小内容宽度（不被 wrap 压缩），对齐非打印态
+  // antd Table 的 min-width 行为：
+  //   - 屏幕态：超宽时由 wrap (overflow-x:auto) 出独立横向滚动条
+  //   - 打印态：与屏幕态一致保持自然列宽，超 A4 部分由 chrome 截断；
+  //     如果这里改成 min-width:0，table 会被 A4 物理宽度压缩，文字竖排，
+  //     与屏幕预览效果不一致（用户实测验证）。已知 A4 物理极限可由用户
+  //     在系统打印对话框切换横向 / A3 / 缩放比例解决。
+  min-width: max-content;
 
   th,
   td {

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
@@ -279,6 +279,24 @@
     white-space: nowrap;
   }
 
+  // 长文本列宽防御。详见 .github/instructions/print-input-table.instructions.md §8.2。
+  //
+  // table 用 table-layout:auto + min-width:max-content，长文本（如 32 字备注）
+  // 会把单列撑到 461px，整张表 1276px 超 A4 横向（~1100px）。这里统一给所有数据
+  // 单元格设 max-width=320px：
+  //   - 长文本会折行（14px 字体下 320px 约 22 ASCII / 11 中文，备注 2-3 行即可）
+  //   - 数字 / 日期 / 短 select 内容 max-content 自然 < 200px，不会触发折行，
+  //     无需 per-type 区分
+  //   - 表头不会 > 320px（截至当前没有 22+ 字 label）
+  //   - __index 列已有 width:40px，排除掉避免被 max-width 覆盖
+  // 未来若数字字段加业务后缀超过 320px 被折行，再加 per-type nowrap class；
+  // 等宽列布局对齐屏幕态的方案见 steedos/steedos-widgets#651。
+  td:not(.steedos-print-input-table__index) {
+    max-width: 320px;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
   // 打印态图片字段：固定缩略尺寸，避免高分图把行撑爆；多图横排
   // 对应 _printTableFormatImage 输出的 <img class="steedos-print-input-table__img"/>
   .steedos-print-input-table__img {

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less
@@ -157,28 +157,33 @@
 // 仅在审批打印页（/page/page_instance_print）生效，绕开 antd Table，输出纯静态 HTML 表格
 .steedos-print-input-table-wrap {
   width: 100%;
-  // 当子表列总宽超过容器时，由 wrap 自身出横向滚动条。
-  // 用 scroll 而非 auto 的原因：chrome 真打印预览（@media print）下，
-  // overflow:auto 即使有溢出也常常不渲染滚动条 UI（chrome 认为纸张上
-  // 滚动条不可交互所以省略），导致用户在真打印预览看不到"右侧还有内容"
-  // 的视觉提示。改成 scroll 后 chrome 会把滚动条 track 当成实际内容
-  // 一起渲染到打印预览页面右侧 → 起到"右侧被截断"的指示作用
-  // （issue steedos/steedos-plugins#744 真打印态滚动条指示）。
-  overflow-x: scroll;
-  overflow-y: hidden;
-  // 自定义 webkit 滚动条样式，确保打印预览里也能看见浅灰 track + 深灰 thumb
-  // chrome 打印引擎尊重 ::-webkit-scrollbar 自定义样式；如果只依赖系统默认
-  // overlay 滚动条（macOS），打印预览可能完全空白看不到指示
-  &::-webkit-scrollbar {
-    height: 8px;
-    -webkit-appearance: none;
-  }
-  &::-webkit-scrollbar-track {
-    background: #f1f1f1;
-  }
-  &::-webkit-scrollbar-thumb {
-    background: #888;
-    border-radius: 4px;
+  // 屏幕态：overflow-x: auto，由系统决定是否渲染滚动条（macOS overlay
+  // 默认无 track，hover 时才显示 thumb；windows/linux 始终显示）。
+  // 不在这里加 ::-webkit-scrollbar 自定义样式，否则会破坏与主分支屏幕态
+  // 一致的原生滚动条体验（用户反馈）
+  overflow-x: auto;
+
+  // 真打印预览态：chrome @media print 下 overflow:auto 即使有溢出也常常
+  // 省略滚动条 UI（认为打印纸张上不可交互）。改成 scroll 强制渲染滚动条
+  // track；同时自定义 webkit 样式确保打印引擎采用浅灰 track + 深灰 thumb
+  // 作为"右侧被截断"的视觉指示（macOS overlay 滚动条打印时本来也不可见）。
+  // 仅限 @media print，屏幕态完全不受影响
+  // （issue steedos/steedos-plugins#744 真打印态滚动条指示）
+  @media print {
+    overflow-x: scroll;
+    overflow-y: hidden;
+
+    &::-webkit-scrollbar {
+      height: 8px;
+      -webkit-appearance: none;
+    }
+    &::-webkit-scrollbar-track {
+      background: #f1f1f1;
+    }
+    &::-webkit-scrollbar-thumb {
+      background: #888;
+      border-radius: 4px;
+    }
   }
 }
 


### PR DESCRIPTION
## 背景
仓库 `steedos/steedos-plugins#744`：审批打印页（`/page/page_instance_print`）的子表（input-table）在 A4 打印输出时会出现线条失真、表头文字被压成单字竖排、长文本截断、整页结构残缺等问题。

根因：打印场景仍然使用交互式 `amis input-table` → `antd Table` 渲染，其内部依赖固定列宽测量、滚动容器、虚拟列表、固定列 sticky 定位等 JS 排版机制，与 chrome 打印引擎分页 + A4 物理宽度叠加后视觉断裂。

## 修复方案
在打印场景下，把子表渲染从交互式表格切换为**纯静态 HTML 表格** schema（amis `tpl`）：
- 用 `<table>` 直接输出表头与行数据，绕开 amis input-table / antd Table 整个渲染管线
- 采用 `table-layout: auto` + `min-width: max-content` + `word-break: normal / overflow-wrap: break-word`，让列宽按内容自适应、长文本按字换行
- 表头取 `field.label`，行值通过 `_printTableFormatCell` + `_printTableEvalFieldTpl` 处理 boolean / array / object / 数字千分位 / 带 `tpl` 字段（如 select / lookup）

普通预览 / 编辑场景的代码路径完全不变。

## 触发条件（任一）
1. `props.print === true`（预留显式声明链路，方便后续上层接入）
2. URL `pathname` 命中 `/page/page_instance_print`（主路径，已验证生效）
3. `localStorage.STEEDOS_PRINT_INPUT_TABLE = '1'`（调试 / 灰度兜底）

## 改动文件
- `packages/@steedos-widgets/amis-lib/src/lib/input_table.js`
  - 新增 `isPrintInputTableEnabled` / `escapeHtmlForPrintTable` / `getPrintInputTableSchema`
  - `getAmisInputTableSchema` 入口加分支：命中打印场景时直接返回静态表格 schema
  - `_printTableFormatCell` / `_printTableFormatNumber` / `_printTableEvalFieldTpl` 单元格格式化辅助函数
- `packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less`
  - 追加 `.steedos-print-input-table` / `.steedos-print-input-table-wrap` / `.steedos-print-input-table-host` 样式块
- `.github/instructions/print-input-table.instructions.md` *(新增)*
  - 子表打印模式开发指南：规则来源原则、字段类型覆盖矩阵、tpl 安全约束、验证流程、commit 历史教训、设计决策记录

## 字段类型覆盖

### ✅ 已覆盖（本 PR 当前 commit）

| Steedos 类型 | amis 中间 type | 处理方式 |
|---|---|---|
| text / textarea / autonumber / url / email / password | `static` | 原值 |
| number / currency / percent | `input-number` (`static:true`) | `_printTableFormatNumber` 按原始小数位千分位 |
| select / boolean / lookup（schema 含 `tpl`） | 带 `tpl` 的 `static` | `_printTableEvalFieldTpl` 预编译 lodash template |
| boolean（无 tpl 兜底） | — | "是" / "否" |
| 数组 / 对象 | — | `join(', ')` 或 `name/label/value` 取值 |

规则来源：实测非打印态 `page_instance_view` 同一记录的单元格 textContent，1:1 对齐。

### ⏳ 未覆盖（计划本 PR 内独立 commit 补充）

> ℹ️ 本节是 D 阶段执行前的状态快照；最新覆盖情况见底部「D 阶段：未覆盖字段类型补全」章节。

| Steedos 类型 | 应有行为（参考 amis renderer） | 优先级 |
|---|---|---|
| date / datetime / time | 按字段 `format` 格式化（`Date.tsx`） | 高 |
| multi-select（multiple:true） | 映射为 label 数组 | 高 |
| image | 渲染缩略图（`Image.tsx`） | 中 |
| file | 文件名 + 下载链接（`File.tsx`） | 中 |
| formula / summary | 取 `row._display[name]` 兜底，需验证 | 中 |
| master_detail | 关联记录 name | 中 |
| html / markdown | 渲染为 DOM | 低 |
| color | 渲染色块 | 低 |

补全原则严格遵循 [.github/instructions/print-input-table.instructions.md](.github/instructions/print-input-table.instructions.md) — 先看 `AmisSteedosField.tsx` + amis renderer 源码，再 hand-port 到 print tpl，UI 实测验证。

## 二阶段回归修复（commit `e6797b2a2` → `7f1018262`）

主线 mainline (`78660e12d` → `d239709f8`) 验收通过后，发现 T5 (25 列子表 `recordId=69dce2bd1f5fd36df3a218b9`) 的两个回归 + 用户体验问题，已通过 5 个 commit 串联修复：

| Commit | 问题 | 修复 |
|---|---|---|
| `e6797b2a2` | 22+ 列超宽子表把外层审批单一路撑宽，最外层出现页面级横向滚动条 | `.steedos-print-input-table-wrap` 加 `overflow-x: auto` |
| `bff02ad64` | 上一步只加 wrap overflow 不生效，DevTools 实测 `wrap.scrollWidth === wrap.clientWidth` 根本没溢出 | 双重根因：1) `table-layout:auto` 把列压缩到适应 wrap → table 永不溢出，加 `table { min-width: max-content }` 让 table 主张自然宽度；2) HTML `<table class="form-table">` 列宽算法反向把子表 max-content 传到 td，给 `.steedos-print-input-table-host` 加 `contain: inline-size` 切断子树对父 size 贡献 |
| `41b6f3bea` | 上一步给打印态加 `@media print { contain:none; min-width:0 }` 后真打印窗口表头按字符竖排（25 列 / 750px = 30px/列） | 删除全部 `@media print` overrides，两态视觉完全统一；超 A4 由 chrome 自然截断 |
| `1c9c87eba` | 真打印预览看不到右侧截断指示 | wrap 用 `overflow-x: scroll` + `::-webkit-scrollbar` 自定义样式（暂时方案，真打印预览滚动条渲染问题作为已知 follow-up） |
| `7f1018262` | 上一步把屏幕态滚动条也改成自定义样式，与主分支体验不一致 | 把 `overflow-x:scroll` + 自定义样式包进 `@media print`，屏幕态保留 `overflow-x: auto` 系统原生滚动条 |

### 设计决策 D1（采用）vs D2（已舍弃）
详见 [.github/instructions/print-input-table.instructions.md §8.2](.github/instructions/print-input-table.instructions.md)：

- **D1（当前）**：打印态与屏幕态视觉完全一致 — 列宽 max-content 自然分配，超 A4 由 chrome 截断。用户可通过系统打印对话框切换"横向 / A3 / 缩放比例"看到完整内容
- **D2（已舍弃）**：跟进主分支让打印态压缩列宽塞下全部列。舍弃原因：25 列 / ~750px = 30px/列时表头按字符竖排（实测截图证据）、数字短串"23232"也会被错切，与 PR #650 主线"消除打印失真"目标冲突；切回方案文档已留 5 行 CSS 切换片段

## 验证
基于本地真实环境，使用 Chrome CDP 对 7 个真实审批单（覆盖单子表 / 多子表 / 长文本 / 多列 / 25 列超宽场景）生成 A4 PDF 对比：

| 样本 | 子表场景 | 修复前 | 修复后 |
|---|---|---|---|
| T0 | 6 列 3 行 | 基本可读 | ✅ 完美 |
| T1 | 单子表 + 单行 | 可读 | ✅ 完美 |
| T2 | 4 个子表 | 部分失真 | ✅ 完美 |
| T3 | 长文本 | 表头压成单字竖排、整页残缺 | ✅ 完美，长文本正常换行 |
| T4 | 10 列中等宽度 | 偶发截断 | ✅ 完美，数字千分位生效，子表自身出独立横向滚动条 |
| T5 | 25 列超宽 | 物理极限受限，外层审批单被撑爆 | ✅ 子表自身出独立横向滚动条，外层审批单不撑宽；超 A4 由 chrome 截断 |
| T6 | 22 列超宽 | 物理极限受限 | ✅ 同 T5 |

二阶段 DevTools 自验证（T5, recordId `69dce2bd1f5fd36df3a218b9`）：
- `wrap`: clientW=760, scrollW=1921, has_h_scroll=true ✓
- `host`: contain=inline-size, clientW=scrollW=760 ✓
- `instance_template`: clientW=scrollW=764, has_h_overflow=false ✓
- 页面级 `html_has_h_scroll`: false ✓
- 单元格高度 29px（之前 146px 文字竖排）✓

## 已知限制 / 兜不住的地方

详见 [.github/instructions/print-input-table.instructions.md §8](.github/instructions/print-input-table.instructions.md)：

- **A4 物理极限**：超长字段 / 超多列导致总宽 > A4，超出部分由 chrome 截断到纸张右侧。用户解法：系统打印对话框切换"横向 / A3 / 缩放比例"，或在屏幕态把 wrap 滚到右侧再点打印（chrome 按当前 scroll 位置截取）
- **真打印预览滚动条渲染**：当前 `@media print { overflow-x: scroll + ::-webkit-scrollbar }` 方案在测试机上未稳定渲染。作为已知 follow-up，等待对照另一台机器 CSS-only 版本补
- **预览页面视觉差异**：打印预览页面的子表是静态 HTML，跟非打印 `page_instance_view` 的 amis 子表视觉上有差异（无排序 / 行 popover / 操作列等交互），但打印场景本不需要这些交互
- **行级 `visible_on` / `hidden_on` 表达式**、**行样式 `rowClassName`**、**自动列**（checkbox / 操作列）：当前静态表不处理，潜在风险，未实测
- 未覆盖字段类型详见上文，本 PR 内独立 commit 跟进

## 风险与影响
- 仅改动子表的打印分支，命中条件强约束（必须是审批打印页或显式 `props.print=true`）；列表 / 编辑 / 弹窗等所有场景的 input-table 行为保持不变
- 内联 `tpl` 使用 lodash template（amis 原生支持），与 amis 表达式引擎不冲突。已避开两个已知坑：tpl 内禁裸 `$`（防 amis builtin 引擎抢占）、禁 `+ // 行尾注释`（防字符串退化为一元 `+` 注入 NaN）
- T5/T6 的物理宽度限制不在本 PR 范围，留待后续 issue 跟进

## 相关
- Fixes (downstream usage): steedos/steedos-plugins#744

---

## D 阶段：未覆盖字段类型补全（commit `ca6d3f990`）

按 [.github/instructions/print-input-table.instructions.md §4](.github/instructions/print-input-table.instructions.md) 字段覆盖矩阵补全 image / file / date / multi-value `_display` 等场景，并修复一处 workflow 表单 date 子表列在打印态输出原始 ISO 字符串的真实回归。

### 真实回归发现
在 record `6984a0e95bbb476eee0a29cf`（车辆加油审批单 / 加油记录子表）上发现 `加油日期`（type=date）在打印态原样输出 `2026-02-10T00:00:00.000Z`。根因双重：
1. 服务端 instances.values 对 subfield 不下发 `_display`
2. workflow 表单 date 字段 tpl 使用 `<%=data.<name> ? date(new Date(data.<name>), 'YYYY-MM-DD') : '' %>`（[`amis-lib/src/workflow/flow.js:779`](packages/@steedos-widgets/amis-lib/src/workflow/flow.js#L779)），打印分支自行预编译 tpl 时缺 `date()` 过滤器 → tpl 抛 "date is not defined" → 被 `_printTableEvalFieldTpl` catch 后 fall back 到原值

修复：给打印分支预编译 tpl 注入 `imports: { date, formatDate, number, formatNumber }`，与 [`amis-core/utils/tpl-lodash.js`](https://github.com/baidu/amis/blob/master/packages/amis-core/src/utils/tpl-lodash.ts) 行为对齐。

### 改动文件
- `packages/@steedos-widgets/amis-lib/src/lib/input_table.js`
  - `getPrintInputTableSchema`：tpl 编译时传入 `imports` 内置 `date/formatDate/number/formatNumber` 实现
  - `_printTableFormatCell`：新增 `Array.isArray(d)` 分支（修复之前 `_display` 为数组时被当 object 返回空串的回归）
  - 字段分发新增 `isPrintImageType / isPrintFileType / isPrintDateType`
  - 新增 runtime helpers：`_printTableEscapeHtml / _printTableNormalizeFiles / _printTableFormatImage / _printTableFormatFile / _printTableFormatDate`
- `packages/@steedos-widgets/amis-object/src/amis/AmisInputTable.less`
  - `.steedos-print-input-table__img`：缩略尺寸 `max-height:60px; max-width:120px; object-fit:contain`
  - `.steedos-print-input-table__file`：屏幕态蓝色下划线，`@media print` 去色去线
- `.github/instructions/print-input-table.instructions.md` §4 覆盖矩阵更新

### 更新后的字段类型覆盖矩阵

| 类型 | 状态 | 说明 |
|---|---|---|
| text / textarea / autonumber / url / email / password | ✅ | 原值 |
| number / currency / percent | ✅ | 千分位 |
| select / boolean / lookup（带 tpl） | ✅ | tpl 求值（含 imports.date/number） |
| boolean（无 tpl 兜底） | ✅ | 是 / 否 |
| 数组 / 对象 | ✅ | join + label/name/value |
| **date / datetime / time** | **✅ live verified** | imports.date 修复 workflow tpl；`_printTableFormatDate` 作为非 tpl 路径兜底 |
| **formula / summary** | ✅ source | `_display` 兜底等价于非打印态；租户内子表无 formula / summary 列 live 样本 → verify-pending |
| **master_detail（单值）** | ✅ source | `_display.label\|name\|value`；租户内子表无 master_detail 列 live 样本 → verify-pending |
| **multi-select / multi-lookup / multi-master_detail** | ✅ source | `_display` 数组 join，租户内无 live 样本 → verify-pending |
| **image / avatar / multi-image** | ✅ source | `_printTableFormatImage` 输出 `<img>`，租户内无 live 样本 → verify-pending |
| **file / multi-file** | ✅ source | `_printTableFormatFile` 输出 `<a>`，租户内无 live 样本 → verify-pending |
| html / markdown / color | ⏳ | 低优先级；当前落字符串兜底转义输出 |

### 验证
- date：✅ live verified（record `6984a0e95bbb476eee0a29cf` reload 后 `td[加油日期]` 由 ISO 变为 `2026-02-10`）
- T4 (`69dced421f5fd36df3a218cc`) / T5 (`69dce2bd1f5fd36df3a218b9`) 回归基线复测：全部通过；T4/T5 子表实际只含 text + number(千分位) 两类列，故本次只能复验这两类不退化
- 加油单 (`6984a0e95bbb476eee0a29cf`) live 复验通过的列类型：text、number(千分位)、date(加油日期)、select 带 tpl(品名)、user/lookup 作为单值对象(驾驶员、车辆管理员)
- formula / summary / master_detail / multi-* / image / file：租户 `fssh1124` 现网 instances 集合内**无**含这些类型的子表样本（MongoDB 全量扫描确认），仅做源码层对齐验证（`_display` 兜底 / `_printTableFormat*` helpers），待出现现网样本后补 live verify

### 已知 follow-up
- html / markdown / color 类型按需补全（参考 §4 注释指引）
- 待租户出现 image / file / multi-select 子表样本后补 live 验证截图
- **架构性 follow-up**：steedos/steedos-widgets#651 — POC 把打印 cell 渲染改为复用 amis static-* renderer，移除整条 hand-port 分支
