### PR TITLE
fix(print-input-table): 子表 radio/checkbox 字段在 label!=value 时正确显示 label

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/lib/__tests__/printInputTable.reuseAmis.test.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/__tests__/printInputTable.reuseAmis.test.js
@@ -176,6 +176,41 @@ describe('buildPrintCellSchema - 枚举类型', () => {
         expect(out).toEqual({ type: 'tpl', tpl: '选项A, 选项B' });
     });
 
+    // ===== radio / checkbox：v1 老审批中是单选/多选选项组，与 select 同源 =====
+    test('radio display 缺失：按 options 反查 label（label != value）', () => {
+        const out = buildPrintCellSchema(
+            { name: 'r', type: 'radio', options: [{ label: '本地', value: '1' }, { label: '异地', value: '2' }] },
+            '2'
+        );
+        expect(out).toEqual({ type: 'tpl', tpl: '异地' });
+    });
+
+    test('radio 无 options + 无 display：原值兜底（兼容 label==value 历史路径）', () => {
+        const out = buildPrintCellSchema({ name: 'r', type: 'radio' }, '异地');
+        expect(out).toEqual({ type: 'tpl', tpl: '异地' });
+    });
+
+    test('checkbox 多选 display 缺失：options 反查 label 后 join(", ")', () => {
+        const out = buildPrintCellSchema(
+            { name: 'c', type: 'checkbox', options: [
+                { label: '选项A', value: 'a' },
+                { label: '选项B', value: 'b' },
+                { label: '选项C', value: 'c' },
+            ] },
+            ['a', 'c']
+        );
+        expect(out).toEqual({ type: 'tpl', tpl: '选项A, 选项C' });
+    });
+
+    test('checkbox display 优先于 options 反查', () => {
+        const out = buildPrintCellSchema(
+            { name: 'c', type: 'checkbox', options: [{ label: '错误', value: 'a' }] },
+            'a',
+            '正确'
+        );
+        expect(out).toEqual({ type: 'tpl', tpl: '正确' });
+    });
+
     test('lookup display 对象 → 取 label/name', () => {
         const out = buildPrintCellSchema(
             { name: 'r', type: 'lookup' },
@@ -340,8 +375,10 @@ describe('normalizeFieldSpecForPrint v1 alias compat', () => {
     test('dateTime -> datetime', () => {
         expect(normalizeFieldSpecForPrint({ name: 'a', type: 'dateTime' }).type).toBe('datetime');
     });
-    test('checkbox -> boolean', () => {
-        expect(normalizeFieldSpecForPrint({ name: 'a', type: 'checkbox' }).type).toBe('boolean');
+    test('checkbox 保留 checkbox 类型（v1 老审批 = 多选选项组，不能映射为 boolean）', () => {
+        // 历史 bug：曾把 checkbox 映射为 boolean，导致 v1 多选选项组被渲染为 ✓/✗，
+        // 永远命中不到 enum case 的 options 反查逻辑。
+        expect(normalizeFieldSpecForPrint({ name: 'a', type: 'checkbox' }).type).toBe('checkbox');
     });
     test('odata -> lookup', () => {
         expect(normalizeFieldSpecForPrint({ name: 'a', type: 'odata' }).type).toBe('lookup');

--- a/packages/@steedos-widgets/amis-lib/src/lib/printInputTableCell.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/printInputTableCell.js
@@ -133,10 +133,13 @@ export const buildPrintCellSchema = (fieldSpec, value, display) => {
             };
         }
 
-        // ===== 枚举类（select / multi-select / lookup / multi-lookup / master_detail / user / group） =====
+        // ===== 枚举类（select / multi-select / radio / checkbox / lookup / multi-lookup / master_detail / user / group） =====
         // 设计：优先用 display（服务端已注入 label）；缺失时按 options 反查 label；
         // 多值统一 join(", ")。单值与多值共享同一路径，靠 normalizeDisplayList 统一处理。
+        // 注意：v1 老审批 checkbox = 多选选项组（不是 v2 的 boolean 开关），必须走 options 反查。
         case 'select':
+        case 'radio':
+        case 'checkbox':
         case 'lookup':
         case 'master_detail':
         case 'user':
@@ -242,7 +245,9 @@ const PRINT_FIELD_TYPE_ALIASES = {
     dateTime: 'datetime',
     datetimepicker: 'datetime',
     datepicker: 'date',
-    checkbox: 'boolean',
+    // 注意：v1 老审批 `checkbox` = 多选选项组（一组 options，可勾多个），
+    // 不能把它映射为 v2 的 `boolean`（单一开关）—— 否则会进 boolean case 输出 ✓/✗，
+    // 永远命中不到 enum case 的 options 反查逻辑。v1 path 直接保留 'checkbox' 类型。
     odata: 'lookup',
     autonumber: 'text',
     masterDetail: 'master_detail',

--- a/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/flow.js
@@ -650,7 +650,7 @@ const getFieldEditTpl = async (field, label, inTable, tableFieldMap)=>{
               if (field._print) {
                 column.config._originalType = sField.type;
                 column.config._is_multiselect = sField.is_multiselect;
-                if (sField.type === 'select') {
+                if (['select', 'radio', 'checkbox'].includes(sField.type)) {
                   column.config._parsedOptions = getSelectOptions(sField);
                 }
               }
@@ -660,7 +660,7 @@ const getFieldEditTpl = async (field, label, inTable, tableFieldMap)=>{
               if (field._print) {
                 column._originalType = sField.type;
                 column._is_multiselect = sField.is_multiselect;
-                if (sField.type === 'select') {
+                if (['select', 'radio', 'checkbox'].includes(sField.type)) {
                   column._parsedOptions = getSelectOptions(sField);
                 }
               }
@@ -908,7 +908,7 @@ const getFieldReadonlyTpl = async (field, label, inTable, tableFieldMap)=>{
           if (field._print) {
             column.config._originalType = sField.type;
             column.config._is_multiselect = sField.is_multiselect;
-            if (sField.type === 'select') {
+            if (['select', 'radio', 'checkbox'].includes(sField.type)) {
               column.config._parsedOptions = getSelectOptions(sField);
             }
           }
@@ -918,7 +918,7 @@ const getFieldReadonlyTpl = async (field, label, inTable, tableFieldMap)=>{
           if (field._print) {
             column._originalType = sField.type;
             column._is_multiselect = sField.is_multiselect;
-            if (sField.type === 'select') {
+            if (['select', 'radio', 'checkbox'].includes(sField.type)) {
               column._parsedOptions = getSelectOptions(sField);
             }
           }


### PR DESCRIPTION
## 背景

在 #651 的 PoC A+（把打印子表 cell 改为复用 `steedos-field static` renderer）验证过程中，借助远程库 `fssh20260518` 的真实数据诊断，定位到 v1 老审批打印子表里 radio / checkbox 字段在 **label != value** 场景下不能正确显示 label 的协同 bug。

PoC A+ 因 `steedos-field` 在 `table-view` td 上下文里读不到注入式 value/data 而被否决（archive 在 `poc/issue-651-steedos-field-cell` 分支）。本 PR 只提取出与 PoC 解耦的 3 处真 bug 修复 + 单测补强。

## 修复内容

**1. `workflow/flow.js`**

`_parsedOptions` 注入条件原本硬编码 `=== 'select'`，遗漏 radio / checkbox 两种 v1 老审批选项组类型。即使打印 schema 收到了字段，`_parsedOptions` 也是空的，后续 cell 渲染无法做 options 反查。

修改为 `['select', 'radio', 'checkbox'].includes(sField.type)`，覆盖 4 个相同分支。

**2. `lib/printInputTableCell.js` — enum case**

`buildPrintCellSchema` 的 enum case switch 原本只列了 `select / lookup / master_detail / user / group`，遗漏 radio / checkbox，即便 `_parsedOptions` 注入了也会 fallthrough 到 default `tpl`，只能输出原始 `value` 字符串。补上 `case 'radio'` 和 `case 'checkbox'` 与 select 同源。

**3. `lib/printInputTableCell.js` — 去掉 `checkbox: 'boolean'` alias**

`PRINT_FIELD_TYPE_ALIASES` 把 `checkbox` 映射成 `boolean` 是错误的——v1 老审批 `checkbox` 是多选选项组（一组 options 可勾多个），不是 v2 的单一布尔开关。映射后会进 boolean case 输出 ✓/✗，永远命中不到上面的 options 反查逻辑。去掉该 alias，保留 checkbox 原类型。

## 测试

- 单测新增 4 项：radio label!=value 反查、radio 无 options 兜底、checkbox 多选反查 join、checkbox display 优先于反查。
- 改写 1 项：checkbox alias 测试现在断言保留 `checkbox` 类型。
- **61/61 通过**（原 57 + 新 4，改 1）。

## 现实场景影响

扫描远程库 `fssh20260518` 81 个 radio/checkbox 子表字段，**当前全部是 label==value 写法**（没踩到本 bug）。但只要业务方写成 `本地:1\n异地:2` 这种 mismatch options，原代码就会显示 raw value。

本修复对 label==value 场景行为不变，零回归风险。

## 验证

- `yarn jest packages/@steedos-widgets/amis-lib/src/lib/__tests__/printInputTable.reuseAmis.test.js` → 61 passed
- `yarn build-object` → success
- Chrome 实测远程库实例 `5hWApD6nfvEFcigAH`（`fssh20260518`），子表 group 字段 `预留提报单位` 仍正确显示 `生产分厂` —— 不回归。
- radio/checkbox label!=value 场景待后续业务测试或造单验证（已通过单测覆盖）。

## 关联

- Refs steedos/steedos-widgets#651（PoC A+ 否决后定位的协同 bug）
- 与 #654 等子表打印类 PR 不冲突