### PR TITLE
fix(calendar): make timeline event full height opt-in

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/lib/converter/amis/calendar.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/converter/amis/calendar.js
@@ -656,7 +656,6 @@ export async function getObjectCalendar(objectSchema, calendarOptions, options) 
     const groupField = objectSchema.fields[groupFieldName];
     let groupObjectName = groupField?.reference_to;
     let groupHeaderTitle = "资源";
-    const groupedTimelineClassName = "steedos-fullcalendar-grouped-timeline";
     if (groupObjectName){
       const groupObjectConfig = getUISchemaSync(groupObjectName);
       groupHeaderTitle = groupObjectConfig?.label || groupHeaderTitle;
@@ -665,11 +664,14 @@ export async function getObjectCalendar(objectSchema, calendarOptions, options) 
       // "height": "auto",
       initialView: 'resourceTimelineWeek',
       resourceAreaHeaderContent: groupHeaderTitle,
-      className: _.compact([config.className, groupedTimelineClassName]).join(" "),
       "headerToolbar": {
         "right": headerToolbarViews
       }
     });
+  }
+
+  if (calendarOptions.eventFullHeight === true) {
+    config.className = _.compact([config.className, "steedos-fullcalendar-event-full-height"]).join(" ");
   }
 
   const amisSchema = {

--- a/packages/@steedos-widgets/amis-lib/src/lib/objects.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/objects.js
@@ -251,6 +251,9 @@ function getCalendarOptions(listView) {
     if (listView.calendar_group_field) {
         calendarDefaults.groups = [listView.calendar_group_field];
     }
+    if (listView.calendar_event_full_height !== undefined) {
+        calendarDefaults.eventFullHeight = listView.calendar_event_full_height;
+    }
 
     const resourceDefaults = {};
     if (listView.calendar_resource_color_field) {

--- a/packages/@steedos-widgets/fullcalendar-scheduler/src/components/Calendar.css
+++ b/packages/@steedos-widgets/fullcalendar-scheduler/src/components/Calendar.css
@@ -41,22 +41,22 @@
     background-color: var(--fc-event-bg-color, #3788d8) !important;
 }
 
-.fc .fc-h-event .fc-event-title,
-.fc .fc-timeline-event .fc-event-title {
+.steedos-object-listview .fc .fc-h-event .fc-event-title,
+.steedos-object-listview .fc .fc-timeline-event .fc-event-title {
     overflow: hidden;
     text-overflow: ellipsis;
 }
 
-.steedos-fullcalendar-grouped-timeline .fc-resource-timeline .fc-timeline-event-harness {
+.steedos-fullcalendar-event-full-height .fc-resource-timeline .fc-timeline-event-harness {
     bottom: 0;
 }
 
-.steedos-fullcalendar-grouped-timeline .fc-resource-timeline .fc-timeline-events {
+.steedos-fullcalendar-event-full-height .fc-resource-timeline .fc-timeline-events {
     height: 100% !important;
     padding-bottom: 0 !important;
 }
 
-.steedos-fullcalendar-grouped-timeline .fc-resource-timeline .fc-timeline-event {
+.steedos-fullcalendar-event-full-height .fc-resource-timeline .fc-timeline-event {
     height: 100%;
     margin-bottom: 0;
     box-sizing: border-box;


### PR DESCRIPTION
Follow-up for #657.

## 背景

#658 把 `calendar_group_field` 分组 timeline 默认加上了满高样式。这个默认策略过宽：`calendar_group_field` 只表示按资源分组，不代表同一 resource lane 业务上一定互斥。比如会议室预订可以通过服务端触发器保证同会议室同时间不冲突，但其他按资源分组的对象可能允许并发。

## 改动

- 新增 listview 配置：`calendar_event_full_height: true`
- `objects.js#getCalendarOptions` 将该配置映射为 `calendarOptions.eventFullHeight`
- `calendar.js#getObjectCalendar` 只有在 `eventFullHeight === true` 时才注入 `steedos-fullcalendar-event-full-height` class
- 不再因为 `calendarOptions.groups` 非空自动注入满高 class
- CSS class 从 `steedos-fullcalendar-grouped-timeline` 改为语义更准确的 `steedos-fullcalendar-event-full-height`
- 省略号样式收敛到 `.steedos-object-listview` 下，避免影响页面上非对象列表视图中的 FullCalendar 实例

## 使用方式

需要事件填满 resource timeline lane 的 listview 显式配置：

```yaml
calendar_event_full_height: true
```

该配置不强制依赖 `calendar_group_field`；但 CSS 只命中 `.fc-resource-timeline`，普通 calendar/timeGrid/dayGrid 视图不会受影响。

## 验证

- `yarn build-object` 通过
- `packages/@steedos-widgets/fullcalendar-scheduler && yarn build` 通过
- 浏览器验证：
  - 未配置 opt-in 时，分组 timeline 不再自动满高
  - 给 calendar root 加 `steedos-fullcalendar-event-full-height` 后，事件高度从 27/28 恢复到约 38，与 lane 高度 38.5/39 对齐
  - 事件标题省略号仍生效，`title` hover 保持完整标题