### PR TITLE
fix(amis-object): forward eventFullHeight prop to calendar schema

### DIFF
--- a/packages/@steedos-widgets/amis-object/src/amis/AmisObjectCalendar.tsx
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisObjectCalendar.tsx
@@ -9,7 +9,7 @@ import { getCalendarSchema } from '@steedos-widgets/amis-lib'
 
 export const AmisObjectCalendar = async (props) => {
   console.log(`AmisObjectCalendar props`, props)
-  const { $schema, top, sort, filters, filtersFunction, title, currentView, startDateExpr, endDateExpr, allDayExpr, textExpr, groups, resources, data, defaultData, className="", onEvent, config} = props;
+  const { $schema, top, sort, filters, filtersFunction, title, currentView, startDateExpr, endDateExpr, allDayExpr, textExpr, groups, resources, eventFullHeight, data, defaultData, className="", onEvent, config} = props;
 
   let objectApiName = props.objectApiName || "events";
 
@@ -23,7 +23,8 @@ export const AmisObjectCalendar = async (props) => {
     allDayExpr,
     textExpr,
     groups, 
-    resources
+    resources,
+    eventFullHeight
   }, { top, sort, filter: filters, filtersFunction, onEvent, config, id }));
   const uiSchema = schema.uiSchema;
   const amisSchema = schema.amisSchema;


### PR DESCRIPTION
## Problem

After merging PR #659, configuring `calendar_event_full_height: true` in a timeline listview YAML did not actually apply the `steedos-fullcalendar-event-full-height` class at runtime, so events still did not fill the resource row height.

## Root cause

PR #659 wired the option through two layers:
- `objects.js#getCalendarOptions`: maps `listView.calendar_event_full_height` -> `calendarOptions.eventFullHeight`
- `calendar.js#getObjectCalendar`: appends the CSS class when `calendarOptions.eventFullHeight === true`

But the runtime pipeline goes through a third layer in `amis-object`:

```
getListSchema  -->  { type: 'steedos-object-calendar', ...calendarOptions }
                                |
                                v
AmisObjectCalendar(props)  -->  getCalendarSchema(appName, objectName, { ...subset of props })
```

`AmisObjectCalendar` destructures props by name and forwards only a fixed subset (title / currentView / startDateExpr / endDateExpr / allDayExpr / textExpr / groups / resources). `eventFullHeight` was never picked up, so by the time `getCalendarSchema` -> `getObjectCalendar` ran, `calendarOptions.eventFullHeight` was `undefined`.

## Fix

Add `eventFullHeight` to the destructured props in `AmisObjectCalendar.tsx` and pass it through to `getCalendarSchema`.

## Verification

- Local rebuild via `yarn build-object`.
- Reload `/app/meeting/meeting` (timeline listview with `calendar_event_full_height: true`).
- DOM now contains `.steedos-fullcalendar-event-full-height` on the form-item wrapper.
- Event height jumps from ~27 to ~37 px (lane height 37.5).
- Removing the listview option restores default rendering (verified previously).