### PR TITLE
fix(workflow): 子表行表单 safeCode 别名从真实行数据初始化 (#660 回归)

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/input_table.js
@@ -614,10 +614,17 @@ function getFormPaginationWrapper(props, form, mode) {
     let primaryKey = getTablePrimaryKey(props);
     // Issue steedos/steedos-widgets#660 — 若 form 上预先标记了 safeCode 别名对，把它们注入到 innerForm.data，
     // 这样首次构建 data scope 时 amis 即可基于 raw 字段值算出 safeCode 别名键，公式字段不再「数字无效」。
+    //
+    // 注意：早期实现把 alias 表达式写成 "${&['raw']}"，依赖同一个 data spec 中 "&" 先被求值，
+    // 但 amis 构建 data scope 时不保证同 spec 内键的求值顺序，对于存量行 + readonly 子字段场景，
+    // alias 会被初始化为空字符串，导致公式字段拿不到依赖值（参见 #660 reopen 评论）。
+    // 这里改为直接复用与 "&" 完全相同的行数据表达式，再用 bracket 取 raw 字段，
+    // 彻底脱离 data spec 内部的求值顺序依赖。
     let aliasDataSpec = {};
     if (form && Array.isArray(form.__aliasFieldNamePairs)) {
+        const rowExpr = "(__super.parent ? __tableItems[__parentIndex]['children'][__super.index] : __tableItems[__super.index])";
         for (const [raw, safe] of form.__aliasFieldNamePairs) {
-            aliasDataSpec[safe] = "${&['" + raw.replace(/'/g, "\\'") + "']}";
+            aliasDataSpec[safe] = "${" + rowExpr + "['" + raw.replace(/'/g, "\\'") + "']}";
         }
     }
     let innerForm = Object.assign({}, form, {


### PR DESCRIPTION
## 背景

PR #661 在「依赖字段默认值均为 0 的新增行」场景下表面修复了 #660，但在以下场景下出现回归：

- 存量行有非零 raw 值
- 子字段为 readonly / static，没有 onChange 触发 raw→safe 同步

公式字段拿不到依赖值，初次显示为 0，且修改可编辑的依赖字段后仍不实时重算。

## 根因

PR #661 在 `innerForm.data` 中注入：

```js
{
  "&": "${... __tableItems[__super.index]}",
  "加油量_L": "${&['加油量（L）']}"
}
```

`${&['raw']}` 依赖同一个 `data` spec 中 `&` 先求值，但 amis 构建 data scope 时并不保证同 spec 内键的求值顺序，结果 alias 被初始化为空字符串。

PR #660 在原场景看起来修复，是因为空字符串经数字渲染 toFixed 后视觉上同样是 `0.00`，掩盖了 alias 没真正生效的事实。

## 修复

把 alias 表达式直接改为与 `&` 完全相同的行数据表达式，再用 bracket 取 raw 字段，彻底脱离 data spec 内部的求值顺序依赖：

```js
const rowExpr = "(__super.parent ? __tableItems[__parentIndex]['children'][__super.index] : __tableItems[__super.index])";
aliasDataSpec[safe] = "${" + rowExpr + "['" + raw.replace(/'/g, "\\'") + "']}";
```

## 浏览器验收

两个场景在仓库本地 `yarn build-object` 后均通过：

**场景 A（#660 原场景，chenzhipei@hotoa.com 草稿单新增行）**
- 弹窗初始 `本月发生额 = 0.00` ✓
- 改 `燃油费（本地） = 100` → `本月发生额` 实时变 `100.00` ✓

**场景 B（#660 回归，ldy-sc@petrochina.com.cn 待审核单第一行编辑）**
- 弹窗初始 `金额（含税） = 364.00`（= 40 × 9.10）✓
- 改 `单价（含税） = 9.20` → `金额（含税）` 实时变 `368.00` ✓

## 其他

- `npx jest` 全绿（180 passed）
- 仅改 `packages/@steedos-widgets/amis-lib/src/lib/input_table.js` 一处

Closes #660