### PR TITLE
feat(listview): support auto_open_filter to auto-expand filter bar

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/lib/converter/amis/fields_filter.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/converter/amis/fields_filter.js
@@ -395,6 +395,10 @@ export async function getObjectFieldsFilterBarSchema(objectSchema, ctx) {
         let _crudService = _crud && SteedosUI.getClosestAmisComponentByType(_crud.context, "service", {name: "service_object_table_crud"});
         _crudService && _crudService.setData({isFilterRequired: true, isFieldsFilterEmpty: isFieldsFilterEmpty, showFieldsFilter: isFieldsFilterEmpty});
       }
+      // auto_open_filter: 配置为 true 时进入列表视图自动展开过滤栏；不影响 filter_required；split/三栏模式下不生效
+      else if(autoOpenFilter && data.display !== "split"){
+        setData({ showFieldsFilter: true });
+      }
     }
   `;
   const onSearchableFieldsChangeScript = `

--- a/packages/@steedos-widgets/amis-lib/src/lib/objects.js
+++ b/packages/@steedos-widgets/amis-lib/src/lib/objects.js
@@ -491,7 +491,8 @@ export async function getListSchema(
         "crudDataFilter": ctx.crudDataFilter || listView.crudDataFilter ,
         "onCrudDataFilter": ctx.onCrudDataFilter,
         "searchable_default": listView.searchable_default,
-        "filter_required": listView.filter_required
+        "filter_required": listView.filter_required,
+        "auto_open_filter": listView.auto_open_filter
     };
     // console.log(`getListSchema===>`,amisSchema)
     return {

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisObjectTable.tsx
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisObjectTable.tsx
@@ -45,7 +45,7 @@ export const AmisObjectTable = async (props) => {
     sort, sortField, sortOrder, extraColumns, data, defaultData,
     formFactor = window.innerWidth < 768 ? 'SMALL' : 'LARGE',
     className = "", requestAdaptor,  adaptor, filterVisible = true, headerToolbarItems,
-    crudDataFilter, onCrudDataFilter, env, crudMode, hiddenColumnOperation=false, searchable_default, filter_required } = props;
+    crudDataFilter, onCrudDataFilter, env, crudMode, hiddenColumnOperation=false, searchable_default, filter_required, auto_open_filter } = props;
   let ctx = props.ctx;
   let crud = props.crud || {};
   if(!ctx){
@@ -133,7 +133,7 @@ export const AmisObjectTable = async (props) => {
   let tableSchema = await getTableSchema(appId, objectApiName, columns, { 
     filters: tableFilters, filtersFunction, top, sort, sortField, sortOrder, extraColumns, defaults, ...ctx, 
     setDataToComponentId, requestAdaptor, adaptor, filterVisible, headerToolbarItems, 
-    crudDataFilter, onCrudDataFilter, amisData: allData, env, searchable_default, filter_required });
+    crudDataFilter, onCrudDataFilter, amisData: allData, env, searchable_default, filter_required, auto_open_filter });
   let amisSchema: any = tableSchema.amisSchema;
   let uiSchema = tableSchema.uiSchema;
   amisSchema.data = Object.assign({}, amisSchema.data, amisSchemaData);


### PR DESCRIPTION
[Issue steedos/steedos-platform#8349](https://github.com/steedos/steedos-platform/issues/8349)

## 变更

为列表视图实现 `auto_open_filter` 渲染逻辑。

- `packages/@steedos-widgets/amis-lib/src/lib/objects.js` — listSchema 将 `auto_open_filter` 写入 `steedos-object-table`。
- `packages/@steedos-widgets/amis-object/src/amis/AmisObjectTable.tsx` — 解构 prop 并透传给 `getTableSchema`。
- `packages/@steedos-widgets/amis-lib/src/lib/converter/amis/fields_filter.js` — 非 lookup 分支在现有 `filter_required` 块之后追加：
  ```js
  else if(autoOpenFilter && data.display !== "split"){
    setData({ showFieldsFilter: true });
  }
  ```

## 行为规则

1. 默认 `false`，向后兼容。
2. 仅当显式 `true` 时初次加载自动展开过滤栏。
3. **不影响 `filter_required`** 行为（更高优先级的必填约束保持不变）。
4. **不在 split/三栏模式下生效**（分栏模式自动弹出搜索表单过于唐突）。

## 配套 platform PR

补充 schema 声明，参见 platform 仓库同名分支 PR。

## 测试

通过 puppeteer-core 控制 Chrome 验证：
- 加上 `auto_open_filter: true` 后，列表视图初次进入搜索栏自动展开 ✅
- 移除该配置后保持原有默认收起行为 ✅
