### PR TITLE
修复部门字段显示完整路径

### DIFF
--- a/packages/@steedos-widgets/amis-object/src/components/SteedosOrgSelector.tsx
+++ b/packages/@steedos-widgets/amis-object/src/components/SteedosOrgSelector.tsx
@@ -95,6 +95,13 @@ interface OrgValueItem {
   fullname: string;
 }
 
+const getOrgDisplayName = (org: any): string => {
+  const name = String(org?.name || '').trim();
+  const fullname = String(org?.fullname || '').trim();
+
+  return fullname || name;
+};
+
 interface DeptGroupSelectorProps {
   name?: string;
   value?: OrgValueItem | OrgValueItem[] | string | string[];
@@ -546,7 +553,7 @@ export const SteedosOrgSelector: React.FC<DeptGroupSelectorProps> = (props) => {
                       </div>
                       {org.fullname && org.fullname !== org.name && (
                         <div style={{ fontSize: 12, color: '#999', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                          {org.fullname}
+                          {getOrgDisplayName(org)}
                         </div>
                       )}
                     </div>
@@ -577,14 +584,13 @@ export const SteedosOrgSelector: React.FC<DeptGroupSelectorProps> = (props) => {
       )}
     </div>
   );
-
   return (
     <div style={{ ...style }} className='steedos-org-selector'>
       <Input
         readOnly
         disabled={isReadOnly}
         placeholder={placeholder}
-        value={selectedOrgs.map(o => o.name).join(', ')}
+        value={selectedOrgs.map(getOrgDisplayName).join(', ')}
         onClick={isReadOnly ? undefined : handleOpen}
         onMouseEnter={() => !isMobile && setInputHovered(true)}
         onMouseLeave={() => !isMobile && setInputHovered(false)}
@@ -739,6 +745,7 @@ export const SteedosOrgSelector: React.FC<DeptGroupSelectorProps> = (props) => {
               )}
               <div style={{ flex: 1, overflowY: 'auto', WebkitOverflowScrolling: 'touch' as any }}>
                 {tempSelectedOrgs.length > 0 ? tempSelectedOrgs.map((org, index) => {
+                  const displayName = getOrgDisplayName(org);
                   const isDragging = dragActiveIndex === index;
                   const isDropTarget = dropTargetIndex === index && dragActiveIndex !== null && dragActiveIndex !== index;
                   const touchProps = bindTouchSort(index);
@@ -764,8 +771,8 @@ export const SteedosOrgSelector: React.FC<DeptGroupSelectorProps> = (props) => {
                       <ApartmentOutlined style={{ color: '#1890ff', flexShrink: 0 }} />
                       <div style={{ flex: 1, minWidth: 0 }}>
                         <div style={{ fontSize: 15, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: 500 }}>{org.name}</div>
-                        {org.fullname && org.fullname !== org.name && (
-                          <div style={{ fontSize: 12, color: '#999', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginTop: 1 }}>{org.fullname}</div>
+                        {displayName !== org.name && (
+                          <div style={{ fontSize: 12, color: '#999', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginTop: 1 }}>{displayName}</div>
                         )}
                       </div>
                       {clearable && (


### PR DESCRIPTION
关联 issue: steedos/steedos-plugins#813

## 修改内容
- 将部门选择组件的展示值收敛为优先使用 fullname，缺失时回退 name。
- 单选输入框、PC 多选已选列表、移动端多选已选列表保持同一展示规则。
- 已移除临时调试日志和临时 placeholder。
- 已移除不必要的 parent 链补齐逻辑，保持最小改动。

## 验证
- 在 widgets 根目录执行 yarn build-object 成功。
- 禁用缓存刷新目标审批单页面，申请部门显示为 财务部/部门领导。

## 多选部门字段测试候选
以下候选来自本地只读查询 MongoDB fssh20260529：启用流程 + forms.current.fields，不含 history 字段。

1. flowId: 26788926d072df95aadea91e
   flowName: 抚顺石化公司调整计划通知单
   formId: b08d04b1687578f9784b2226
   field: 主送单位，type: group，is_multiselect: true

2. flowId: 26788926d072df95aadea91e
   flowName: 抚顺石化公司调整计划通知单
   formId: b08d04b1687578f9784b2226
   field: 抄送单位，type: group，is_multiselect: true

3. flowId: 6eSJEWdbFbRg5vDZf
   flowName: 〖石油三厂〗【综合部】办公会议题审批表
   formId: eyrY9iWQRosu9Xxoj
   field: 列席部门，type: group，is_multiselect: true