### PR TITLE
修复只读部门字段显示完整路径

### DIFF
--- a/packages/@steedos-widgets/amis-object/src/amis/AmisSteedosField.tsx
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisSteedosField.tsx
@@ -163,6 +163,22 @@ async function getLookupLinkOnClick(field: any, options: any) {
     }
 }
 
+const isOrganizationsLookup = (steedosField: any) => {
+    return steedosField?.reference_to === 'organizations' || (isArray(steedosField?.reference_to) && includes(steedosField.reference_to, 'organizations'));
+};
+
+const getLookupObjectDisplayLabel = (steedosField: any, value: any, fallback?: string) => {
+    if (!value) {
+        return fallback;
+    }
+
+    if (isOrganizationsLookup(steedosField)) {
+        return get(value, 'fullname') || get(value, 'name') || fallback;
+    }
+
+    return get(value, 'name') || fallback;
+};
+
 function sanitizeFieldName(code: string): string {
     // Whitelist approach: remove closing parens, then replace any non-safe char with _
     return code.replace(/[）)]/g, '').replace(/[^a-zA-Z0-9_$\u4e00-\u9fff.]/g, '_');
@@ -512,13 +528,17 @@ export const AmisSteedosField = async (props) => {
                         if(values && values.id){
                             values = fieldValue.id;
                             valueOptions = [{
-                                label: fieldValue.name,
+                                label: getLookupObjectDisplayLabel(steedosField, fieldValue, fieldValue.name),
                                 value: fieldValue.id
                             }]
                         }
                         if(isString(values)){
                             values = [values]
                         }
+
+                        const objectFieldValues = steedosField.valueFormat === 'object'
+                            ? (isArray(fieldValue) ? fieldValue : (fieldValue ? [fieldValue] : []))
+                            : [];
 
                         if(steedosField.multiple && steedosField.valueFormat === 'object'){
                             values = map(fieldValue, 'id')
@@ -531,10 +551,11 @@ export const AmisSteedosField = async (props) => {
                             each(values, (value)=>{
                                 const option = valueOptions.find((item)=>item.value === value);
                                 if(option){
+                                    const objectValue = objectFieldValues.find((item: any) => String(item?.id) === String(value));
                                     disPlayValue.push({
                                         objectName: referenceTo,
                                         value: option._id || option.value,
-                                        label: option.label
+                                        label: getLookupObjectDisplayLabel(steedosField, objectValue, option.label)
                                     })
                                 }
                             })


### PR DESCRIPTION
## 说明

- 修复审批任务只读页面中组织/部门 lookup 对象值只显示叶子节点名称的问题
- 只读组织字段显示优先使用 fullname，缺失时回退 name
- 补齐此前可编辑态修复之外的 static lookup 显示链路

关联：steedos/steedos-plugins#813

## 验证

- yarn build-object
- Codex 内置浏览器验证审批任务页：申请部门显示为 财务部/部门领导