### PR TITLE
修复审批列表手机端未使用移动端列配置

### DIFF
--- a/packages/@steedos-widgets/amis-object/src/amis/AmisObjectListview.tsx
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisObjectListview.tsx
@@ -251,7 +251,7 @@ export const AmisObjectListView = async (props) => {
                         );
                         return new Promise((resolve)=>{
                           const listViewSchemaProps = ${JSON.stringify(listViewSchemaProps)};
-                          const formFactor = (["split"].indexOf(display) > -1) ? 'SMALL': defaultFormFactor;
+                          const formFactor = (["split"].indexOf(display) > -1) ? 'SMALL': (defaultFormFactor || listViewSchemaProps.formFactor);
                           listViewSchemaProps.formFactor = formFactor;
                           listViewSchemaProps.displayAs = display;
                           const crud_mode = listView && listView.crud_mode;


### PR DESCRIPTION
关联 issue: https://github.com/steedos/steedos-plugins/issues/821

修复提交: 9f72c0e3e 修复审批列表手机端未使用移动端列配置