### PR TITLE
fix: 适配手机端操作抽屉动态按钮

### DIFF
--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -382,6 +382,14 @@
 
 .steedos-amis-instance-view{
     font-size: .8125rem;
+    --instance-mobile-action-font-size: 14px;
+    --instance-mobile-action-line-height: 21px;
+}
+
+.steedos-amis-instance-view .workflow-form-v2 .steedos-user-selector .ant-input-borderless {
+    font-size: inherit !important;
+    line-height: inherit !important;
+    color: inherit !important;
 }
 
 .steedos-amis-instance-view .instance-name{
@@ -572,6 +580,28 @@
             }
         }
     }
+    .steedos-amis-instance-view.steedos-mobile-view {
+        .steedos-object-record-detail-header,
+        .steedos-object-record-detail-header .antd-Button,
+        .steedos-object-record-detail-header .antd-Button > span,
+        .instance-attachment-toolbar,
+        .instance-attachment-toolbar .steedos-file-upload,
+        .instance-attachment-toolbar .ant-upload-wrapper,
+        .instance-attachment-toolbar .ant-upload,
+        .instance-attachment-toolbar .ant-upload span,
+        .approve-button,
+        .approve-button > span {
+            font-size: var(--instance-mobile-action-font-size) !important;
+            line-height: var(--instance-mobile-action-line-height) !important;
+        }
+
+        .workflow-form-v2 .steedos-user-selector,
+        .workflow-form-v2 .steedos-user-selector *,
+        .workflow-form-v2 label {
+            font-size: 13px !important;
+            line-height: 19.5px !important;
+        }
+    }
     .approval-drawer {
         // 表单项去掉底线（保持紧凑）
         .antd-Form-item {
@@ -608,6 +638,22 @@
         .antd-Drawer-footer {
             border-top: 1px solid #e5e7eb !important;
             padding-top: 8px !important;
+        }
+        .antd-Drawer-footer .antd-Button,
+        .antd-Drawer-footer .antd-Button > span,
+        .antd-Form-value,
+        .antd-Form-value *,
+        .antd-ListControl,
+        .antd-ListControl *,
+        .antd-ListControl-placeholder,
+        .antd-ListControl-item,
+        .antd-ListControl-itemLabel,
+        .antd-RadiosControl,
+        .antd-RadiosControl *,
+        .antd-Checkbox,
+        .antd-Checkbox * {
+            font-size: var(--instance-mobile-action-font-size) !important;
+            line-height: var(--instance-mobile-action-line-height) !important;
         }
         // 核准/驳回 radio 横向排列，左对齐
         .antd-RadiosControl {

--- a/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
+++ b/packages/@steedos-widgets/amis-object/src/amis/AmisInstanceDetail.less
@@ -390,6 +390,7 @@
     font-size: inherit !important;
     line-height: inherit !important;
     color: inherit !important;
+    font-weight: 500 !important;
 }
 
 .steedos-amis-instance-view .instance-name{

--- a/packages/@steedos-widgets/amis-object/src/styles/steedos.css
+++ b/packages/@steedos-widgets/amis-object/src/styles/steedos.css
@@ -31,6 +31,7 @@
   margin: 0;
 }
 
+/* 兼容表单事件脚本运行时追加的 SLDS/Bootstrap 按钮，让它们在手机操作抽屉中保持整行动作项样式。 */
 .buttons-drawer .antd-ButtonGroup button {
   border-color: #c9c9c9;
   border-right: none !important;
@@ -38,6 +39,41 @@
   border-bottom: none !important;
   border-radius: 0px !important;
   min-height: 50px;
+}
+
+.buttons-drawer .antd-ButtonGroup .slds-button,
+.buttons-drawer .antd-ButtonGroup .btn {
+  width: 100% !important;
+  max-width: none !important;
+  min-height: 50px;
+  margin: 0 !important;
+  border-color: #c9c9c9;
+  border-right: none !important;
+  border-left: none !important;
+  border-bottom: none !important;
+  border-radius: 0px !important;
+  background: #fff;
+  color: #151e26;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.buttons-drawer .antd-ButtonGroup .slds-button > a,
+.buttons-drawer .antd-ButtonGroup .btn > a {
+  width: 100%;
+  min-height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+  text-decoration: none;
+}
+
+.buttons-drawer .antd-ButtonGroup .slds-button i,
+.buttons-drawer .antd-ButtonGroup .btn i {
+  margin-right: 3px;
 }
 
 @media screen and (max-width: 767px) {


### PR DESCRIPTION
## 变更说明
- 兼容表单事件脚本运行时追加的 `.slds-button` / `.btn` 动态按钮，让它们在手机端底部操作抽屉中按整行动作项显示。
- 保留原有 `button.antd-Button` 的主题样式，避免影响审批列表等场景里的主按钮蓝底白字效果。

## 验证
- `STEEDOS_UNPKG_URL=http://192.168.1.63:8080 yarn build-object`
- `git diff --check`
- 用户已在公司 IP `192.168.0.110` 环境手动构建 widgets 并验证通过。

关联 issue: https://github.com/steedos/steedos-plugins/issues/832