### PR TITLE
fix: 修复钉钉 PC 审批处理人偶发不显示

### DIFF
--- a/packages/@steedos-widgets/amis-lib/src/workflow/__tests__/approve-dingtalk-pc-reflow.test.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/__tests__/approve-dingtalk-pc-reflow.test.js
@@ -1,0 +1,130 @@
+global.window = {
+  innerWidth: 1024,
+  navigator: {
+    userAgent: "Mozilla/5.0 Chrome/126 Safari/537.36"
+  }
+};
+
+global.document = {
+  querySelector: jest.fn(() => null)
+};
+
+global.BuilderAmisObject = {
+  AmisLib: {
+    createObject: jest.fn((base, extra) => ({ ...(base || {}), ...(extra || {}) }))
+  }
+};
+
+jest.mock("i18next", () => ({
+  t: (key) => ({
+    frontend_workflow_next_step: "下一步",
+    frontend_workflow_next_users: "处理人",
+    frontend_workflow_judge_option_approved: "核准",
+    frontend_workflow_judge_option_rejected: "驳回",
+    frontend_workflow_judge_option_readed: "已阅",
+    frontend_workflow_suggestion_placeholder: "请填写意见"
+  }[key] || key)
+}));
+
+jest.mock("@steedos-widgets/amis-lib", () => ({
+  lookupToAmisPicker: jest.fn(),
+  getSteedosAuth: jest.fn(() => ({ userId: "user-1" })),
+  Router: {}
+}));
+
+jest.mock("../util", () => ({
+  getUserApprove: jest.fn(() => ({
+    _id: "approve-1",
+    type: "approve",
+    handler: "user-1",
+    description: ""
+  })),
+  isCC: jest.fn(() => false),
+  shouldUseAllStepSelection: jest.fn(() => false)
+}));
+
+jest.mock("../nextSteps", () => ({
+  getStepsSchema: jest.fn(() => ({
+    type: "tpl",
+    tpl: ""
+  }))
+}));
+
+const { getApprovalDrawerSchema } = require("../approve");
+
+const walk = (node, predicate, matches = []) => {
+  if (!node || typeof node !== "object") {
+    return matches;
+  }
+  if (predicate(node)) {
+    matches.push(node);
+  }
+  if (Array.isArray(node)) {
+    node.forEach(child => walk(child, predicate, matches));
+    return matches;
+  }
+  Object.values(node).forEach(child => walk(child, predicate, matches));
+  return matches;
+};
+
+const schemaText = (node) => JSON.stringify(node);
+
+const createInstance = () => ({
+  _id: "instance-1",
+  state: "pending",
+  box: "inbox",
+  step: {
+    _id: "step-current",
+    name: "会签",
+    step_type: "sign"
+  },
+  approve: {
+    _id: "approve-1",
+    type: "approve",
+    handler: "user-1",
+    description: ""
+  },
+  flow: {
+    _id: "flow-1"
+  },
+  flowVersion: {
+    _id: "flow-version-1"
+  },
+  trace: {
+    _id: "trace-1"
+  },
+  traces: []
+});
+
+describe("approval DingTalk PC layout reflow", () => {
+  test("injects DingTalk PC layout pulse without replacing next user controls", async () => {
+    const schema = await getApprovalDrawerSchema(createInstance(), {
+      submitEvents: [],
+      nextStepInitedEvents: [],
+      nextStepChangeEvents: [],
+      nextStepUserChangeEvents: []
+    });
+
+    const nextStep = walk(schema, node => node.type === "list-select" && node.name === "next_step")[0];
+    expect(nextStep).toBeTruthy();
+    expect(nextStep.source.adaptor).toContain("__steedosPulseDingTalkPcApprovalLayout");
+
+    const radios = walk(schema, node => node.type === "radios" && node.name === "next_users")[0];
+    expect(radios).toBeTruthy();
+    expect(radios.source.adaptor).toContain("__steedosPulseDingTalkPcApprovalLayout");
+    expect(radios.hiddenOn).toContain("this.new_next_step.deal_type === 'pickupAtRuntime'");
+
+    const checkboxes = walk(schema, node => node.type === "checkboxes" && node.name === "next_users")[0];
+    expect(checkboxes).toBeTruthy();
+    expect(checkboxes.source.adaptor).toContain("__steedosPulseDingTalkPcApprovalLayout");
+
+    const nextUsersService = walk(schema, node => node.id === "u:next_step_users_service")[0];
+    expect(nextUsersService).toBeTruthy();
+    expect(nextUsersService.api.adaptor).toContain("__steedosPulseDingTalkPcApprovalLayout");
+
+    const fullSchema = schemaText(schema);
+    expect(fullSchema).not.toContain("approval-next-users-single-display");
+    expect(fullSchema).not.toContain("approval-dingtalk-pc-display-row");
+    expect(fullSchema).not.toContain("_singleNextUserDisplayName");
+  });
+});

--- a/packages/@steedos-widgets/amis-lib/src/workflow/approve.js
+++ b/packages/@steedos-widgets/amis-lib/src/workflow/approve.js
@@ -25,6 +25,73 @@ const syncSafeFieldNamesScript = `
   };
 `;
 
+const dingtalkPcApprovalLayoutPulseScript = `
+  if (!window.__steedosPulseDingTalkPcApprovalLayout) {
+    window.__steedosPulseDingTalkPcApprovalLayout = function() {
+      try {
+        var ua = navigator.userAgent || "";
+        var isDingTalkPc = ua.indexOf("DingTalk") > -1 && ua.indexOf("DTWKWebView") > -1 && ua.indexOf("webDt/PC") > -1;
+        if (!isDingTalkPc || !document.querySelector(".approval-drawer")) {
+          return;
+        }
+
+        var candidates = [
+          document.documentElement,
+          document.body,
+          document.querySelector("#root"),
+          document.querySelector(".steedos")
+        ];
+        var targets = [];
+        candidates.forEach(function(target) {
+          if (target && targets.indexOf(target) < 0) {
+            targets.push(target);
+          }
+        });
+        if (!targets.length) {
+          return;
+        }
+
+        var states = targets.map(function(target) {
+          return {
+            target: target,
+            width: target.style.width,
+            minWidth: target.style.minWidth,
+            boxSizing: target.style.boxSizing
+          };
+        });
+
+        targets.forEach(function(target) {
+          var rect = target.getBoundingClientRect();
+          target.style.boxSizing = "border-box";
+          target.style.width = Math.max(1, Math.round(rect.width) - 1) + "px";
+          target.style.minWidth = "0";
+          void target.offsetWidth;
+        });
+
+        requestAnimationFrame(function() {
+          states.forEach(function(state) {
+            state.target.style.width = state.width;
+            state.target.style.minWidth = state.minWidth;
+            state.target.style.boxSizing = state.boxSizing;
+            void state.target.offsetWidth;
+          });
+
+          var resizeEvent;
+          if (typeof Event === "function") {
+            resizeEvent = new Event("resize");
+          } else {
+            resizeEvent = document.createEvent("Event");
+            resizeEvent.initEvent("resize", true, true);
+          }
+          window.dispatchEvent(resizeEvent);
+        });
+      } catch (e) {}
+    };
+  }
+  setTimeout(window.__steedosPulseDingTalkPcApprovalLayout, 120);
+  setTimeout(window.__steedosPulseDingTalkPcApprovalLayout, 360);
+`;
+
 const getJudgeOptions = async (instance) => {
   const { step } = instance;
   const options = [];
@@ -221,6 +288,7 @@ const getNextStepInput = async (instance, nextStepChangeEvents) => {
                     }
                   }, 100)
                 }
+                ${dingtalkPcApprovalLayoutPulseScript}
                 return payload;
               `,
               "data": {
@@ -321,6 +389,7 @@ const getNextStepUsersInput = async (instance, nextStepUserChangeEvents) => {
                   setTimeout(function(){
                     try { context._scoped.doAction({ actionType: 'setValue', componentId: 'instance_approval', args: { value: { _nextStepUsersSourceError: null, hasNextUsers: payload.data.hasNextUsers } } }); } catch(e){}
                   }, 0);
+                  ${dingtalkPcApprovalLayoutPulseScript}
                   return payload;`
               },
             body: [
@@ -434,6 +503,7 @@ const getNextStepUsersInput = async (instance, nextStepUserChangeEvents) => {
                     value: value,
                     options: payload.nextStepUsers
                   };
+                  ${dingtalkPcApprovalLayoutPulseScript}
                   return payload;`,
                 "data": {
                   "&": "$$",
@@ -522,6 +592,7 @@ const getNextStepUsersInput = async (instance, nextStepUserChangeEvents) => {
                     value: nextUsersValue,
                     options: payload.nextStepUsers
                   };
+                  ${dingtalkPcApprovalLayoutPulseScript}
                   return payload;`,
                 "data": {
                   "&": "$$",


### PR DESCRIPTION
## 修复内容
- 针对 Mac PC 钉钉 DTWKWebView，在审批签批抽屉异步加载下一步/处理人后触发布局重排。
- 保留原 next_users radios/checkboxes 控件和提交字段，不新增替代展示行。
- 增加回归测试，防止误把处理人控件替换为只读展示。

## 影响范围
- 仅在 UA 同时包含 DingTalk、DTWKWebView、webDt/PC 且存在 .approval-drawer 时执行。
- 普通 PC 浏览器、Safari、移动端钉钉不触发该补偿逻辑。

## 验证
- npx jest packages/@steedos-widgets/amis-lib/src/workflow/__tests__/approve-dingtalk-pc-reflow.test.js --runInBand
- STEEDOS_UNPKG_URL=http://192.168.0.165:8080 yarn build-object
- PC 钉钉客户端刷新审批详情页后打开签批抽屉，确认“下一步：一号审批”“处理人：成杰”显示正常，未点击提交。

关联：steedos/steedos-plugins#846