### PR TITLE
feat(liveblocks): 支持配置 @ 默认候选用户

### DIFF
--- a/packages/@steedos-widgets/liveblocks/README.md
+++ b/packages/@steedos-widgets/liveblocks/README.md
@@ -22,6 +22,7 @@ yarn dev
 {
   "type": "rooms-provider",
   "baseUrl": "${context.rootUrl}",
+  "defaultMentionSuggestionsApi": "/api/example/records/${recordId}/mention-users",
   "body": [
     {
       "type": "rooms-comments",
@@ -48,6 +49,8 @@ yarn dev
   ]
 }
 ```
+
+`defaultMentionSuggestionsApi` 可选。输入 `@` 且尚未输入关键词时，组件调用该接口并将返回的用户 ID 数组作为默认候选人；输入关键词后仍调用 `/v2/c/users/search` 搜索全部用户。接口可直接返回数组，也可返回 `{ "data": [] }`。
 
 如果配置了 readonly ，隐藏了所有的编辑框和按钮，相当于 
 

--- a/packages/@steedos-widgets/liveblocks/src/components/Provider.tsx
+++ b/packages/@steedos-widgets/liveblocks/src/components/Provider.tsx
@@ -12,6 +12,7 @@ export const AmisRoomsProvider = (props: any) => {
   const {
     data: amisData,
     baseUrl,
+    defaultMentionSuggestionsApi,
     children,
     body, 
     render,
@@ -115,11 +116,22 @@ export const AmisRoomsProvider = (props: any) => {
 
       // Find a list of users that match the current search term
       resolveMentionSuggestions={async ({ text = "" }) => {
+        const keyword = text.trim();
+        const useDefaultSuggestionsApi = !keyword && defaultMentionSuggestionsApi;
+        const suggestionsUrl = useDefaultSuggestionsApi
+          ? new URL(defaultMentionSuggestionsApi, fixedBaseUrl).toString()
+          : `${fixedBaseUrl}/v2/c/users/search?keyword=${encodeURIComponent(keyword)}`;
+        const authToken = localStorage.getItem("steedos:authToken");
+        const spaceId = localStorage.getItem("steedos:spaceId");
+        const authorization = useDefaultSuggestionsApi && spaceId && authToken
+          ? `Bearer ${spaceId},${authToken}`
+          : `Bearer ${token}`;
         const response = await fetch(
-          `${fixedBaseUrl}/v2/c/users/search?keyword=${encodeURIComponent(text)}`, {
+          suggestionsUrl, {
             headers: {
-              "Authorization": `Bearer ${token}`
-            }
+              "Authorization": authorization
+            },
+            credentials: 'include'
           }
         );
 
@@ -127,8 +139,9 @@ export const AmisRoomsProvider = (props: any) => {
           throw new Error(i18next.t('liveblocks:frontend_fetch_mention_suggestions_error'));
         }
 
-        const userIds = await response.json();
-        return userIds;
+        const result = await response.json();
+        const userIds = Array.isArray(result) ? result : result?.data;
+        return Array.isArray(userIds) ? Array.from(new Set(userIds.filter(Boolean))) : [];
       }}
     >
       {body && render('body', body, {})}

--- a/packages/@steedos-widgets/liveblocks/src/metas/Provider.ts
+++ b/packages/@steedos-widgets/liveblocks/src/metas/Provider.ts
@@ -69,6 +69,11 @@ export default {
           label: "Base URL",
           value: "m-2 flex flex-col gap-y-2"
         },
+        {
+          type: "text",
+          name: "defaultMentionSuggestionsApi",
+          label: "默认@用户接口"
+        },
       ],
     },
   }


### PR DESCRIPTION
## 背景

支持 [PepsiCo BEV Issue #29](https://github.com/steedos/steedos-project-pepsico-bev/issues/29)：评论框输入 `@` 后，默认展示当前审批单相关人员，同时保留搜索其他用户的能力。

## 改动

- 为 `rooms-provider` 增加可选配置 `defaultMentionSuggestionsApi`
- `@` 后尚未输入关键词时，请求该接口作为默认候选来源
- 输入关键词后继续使用原有 `/v2/c/users/search` 全局搜索
- 支持接口直接返回用户 ID 数组或 `{ data: [] }`
- 使用 Steedos 登录凭证请求业务接口，并保留 cookie 认证
- 对返回的用户 ID 去空并去重
- 补充资产编辑器配置项及 README 用法说明

## 影响

业务项目可以自行提供审批参与者接口，无需将审批业务逻辑耦合到通用评论资产中；食品等项目也可复用同一配置。

## 验证

- `yarn build`（`packages/@steedos-widgets/liveblocks`）通过
- 本地 unpkg 服务加载 `assets-dev.json` 验证通过
- 运行中的 Steedos 页面确认从 `127.0.0.1:8080` 加载 `liveblocks.umd.js`、CSS 和 `meta.js`
- `git diff --check` 通过
